### PR TITLE
fix(sol-luna-router): preserve recovered transport warnings

### DIFF
--- a/skills/sol-luna-router/SKILL.md
+++ b/skills/sol-luna-router/SKILL.md
@@ -64,6 +64,9 @@ python3 <skill-dir>/scripts/run_luna_worker.py run \
 The script fixes the worker to `gpt-5.6-luna` with `model_reasoning_effort="max"`, disables
 native multi-agent tools for the worker, invokes Codex without a shell, and returns one JSON
 object containing `thread_id`, `final_response`, usage, and repository metadata.
+Recovered top-level retry errors and completed error items are preserved in the additive
+`warnings` list when the process exits zero and emits both a final agent message and
+`turn.completed`.
 
 Use `--allow-non-git` only when the user explicitly wants work outside a Git repository. Use
 `--events-file /absolute/path/events.jsonl` only when a durable raw trace is needed.
@@ -96,6 +99,8 @@ thread is unavailable or the task has materially changed.
 - If the runner reports an incompatible or unavailable model, stop and report the exact error.
 - If Luna requests broader file ownership, network access, or permissions, return the request to
   the user or revise the plan; do not grant it silently.
-- If JSONL is malformed, the process exits nonzero, or the final response is missing, treat the
-  worker run as failed.
+- Treat a zero-exit run with a final agent message and `turn.completed` as successful even when
+  earlier transport retry or fallback events appear; inspect the returned `warnings` list.
+- If JSONL is malformed, the process exits nonzero, `turn.failed` appears, `turn.completed` is
+  absent, or the final response is missing, treat the worker run as failed.
 - If unrelated user changes block safe verification, report the boundary instead of reverting them.

--- a/skills/sol-luna-router/scripts/run_luna_worker.py
+++ b/skills/sol-luna-router/scripts/run_luna_worker.py
@@ -183,7 +183,8 @@ def parse_events(stdout: str, stderr: str, returncode: int) -> dict[str, object]
     final_response: str | None = None
     usage: object = None
     completed = False
-    reported_error: str | None = None
+    fatal_error: str | None = None
+    warnings: list[str] = []
 
     for line_number, raw_line in enumerate(stdout.splitlines(), start=1):
         if not raw_line.strip():
@@ -209,17 +210,22 @@ def parse_events(stdout: str, stderr: str, returncode: int) -> dict[str, object]
                 text = item.get("text")
                 if isinstance(text, str):
                     final_response = text
+            elif isinstance(item, dict) and item.get("type") == "error":
+                warnings.append(extract_error(item))
         elif event_type == "turn.completed":
             completed = True
             usage = event.get("usage")
-        elif event_type in ("turn.failed", "error"):
-            reported_error = extract_error(event)
+        elif event_type == "turn.failed":
+            fatal_error = extract_error(event)
+        elif event_type == "error":
+            warnings.append(extract_error(event))
 
     if returncode != 0:
-        detail = reported_error or stderr[-STDERR_TAIL_CHARS:] or "no error details"
+        detail = fatal_error or (warnings[-1] if warnings else None)
+        detail = detail or stderr[-STDERR_TAIL_CHARS:] or "no error details"
         raise WorkerRunError(f"Codex exited with status {returncode}: {detail}")
-    if reported_error:
-        raise WorkerRunError(f"Codex reported an error: {reported_error}")
+    if fatal_error:
+        raise WorkerRunError(f"Codex reported a failed turn: {fatal_error}")
     if not completed:
         raise WorkerRunError("Codex did not emit turn.completed")
     if not thread_id:
@@ -232,6 +238,7 @@ def parse_events(stdout: str, stderr: str, returncode: int) -> dict[str, object]
         "final_response": final_response,
         "usage": usage,
         "event_count": len(events),
+        "warnings": warnings,
     }
 
 

--- a/skills/sol-luna-router/scripts/test_run_luna_worker.py
+++ b/skills/sol-luna-router/scripts/test_run_luna_worker.py
@@ -50,7 +50,19 @@ if mode == "failure":
     print(json.dumps({"type": "error", "message": "simulated failure"}))
     raise SystemExit(7)
 print(json.dumps({"type": "thread.started", "thread_id": "thread-123"}))
+if mode == "recovered":
+    print(json.dumps({"type": "error", "message": "Reconnecting after request timed out"}))
+    print(json.dumps({"type": "item.completed", "item": {"type": "error", "message": "Falling back to HTTPS transport"}}))
+if mode == "turn-failed":
+    print(json.dumps({"type": "turn.failed", "error": {"message": "terminal failure"}}))
+if mode == "missing-final-after-error":
+    print(json.dumps({"type": "error", "message": "retry before empty completion"}))
+    print(json.dumps({"type": "turn.completed", "usage": {"input_tokens": 10, "output_tokens": 0}}))
+    raise SystemExit(0)
 print(json.dumps({"type": "item.completed", "item": {"type": "agent_message", "text": "done"}}))
+if mode == "incomplete-after-error":
+    print(json.dumps({"type": "error", "message": "retry was never recovered"}))
+    raise SystemExit(0)
 print(json.dumps({"type": "turn.completed", "usage": {"input_tokens": 10, "output_tokens": 2}}))
 '''
 
@@ -170,6 +182,62 @@ class RunnerTests(unittest.TestCase):
         )
         self.assertEqual(result.returncode, 1)
         self.assertIn("simulated failure", result.stderr)
+
+    def test_recovered_transport_errors_are_returned_as_warnings(self) -> None:
+        result = self.invoke(
+            "run",
+            "--cwd",
+            str(self.repo),
+            "--prompt-file",
+            str(self.prompt),
+            mode="recovered",
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["final_response"], "done")
+        self.assertEqual(
+            payload["warnings"],
+            [
+                "Reconnecting after request timed out",
+                "Falling back to HTTPS transport",
+            ],
+        )
+
+    def test_turn_failed_remains_fatal_even_with_completion_evidence(self) -> None:
+        result = self.invoke(
+            "run",
+            "--cwd",
+            str(self.repo),
+            "--prompt-file",
+            str(self.prompt),
+            mode="turn-failed",
+        )
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("terminal failure", result.stderr)
+
+    def test_recovered_error_without_turn_completed_fails_closed(self) -> None:
+        result = self.invoke(
+            "run",
+            "--cwd",
+            str(self.repo),
+            "--prompt-file",
+            str(self.prompt),
+            mode="incomplete-after-error",
+        )
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("did not emit turn.completed", result.stderr)
+
+    def test_recovered_error_without_final_message_fails_closed(self) -> None:
+        result = self.invoke(
+            "run",
+            "--cwd",
+            str(self.repo),
+            "--prompt-file",
+            str(self.prompt),
+            mode="missing-final-after-error",
+        )
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("did not emit a final agent message", result.stderr)
 
     def test_events_file_preserves_jsonl(self) -> None:
         events_file = self.root / "events" / "worker.jsonl"


### PR DESCRIPTION
## What

- Treat recovered top-level Codex error events and completed error items as non-fatal warnings.
- Return those messages in an additive `warnings` field when the process exits zero and emits a final agent message plus `turn.completed`.
- Keep `turn.failed`, nonzero exit, malformed JSONL, missing completion, and missing final response fail-closed.
- Document the success and failure contract and add regression coverage for every boundary.

## Why

A Luna run can recover from WebSocket retry failures by falling back to HTTPS and then complete successfully. The runner previously retained the earlier retry event as a fatal error even after valid completion evidence.

Fixes #161

## Test Plan

- [x] `python3 skills/sol-luna-router/scripts/test_run_luna_worker.py` (10 passed)
- [x] Independent direct `parse_events` forward test of recovered and fatal event sequences
- [x] `python3 scripts/audit_skill_quality.py sol-luna-router`
- [x] `python3 scripts/validate_skills.py --check`
- [x] `python3 -m pytest -q` (318 passed, 102 subtests passed)
- [x] `python3 -m py_compile skills/sol-luna-router/scripts/run_luna_worker.py skills/sol-luna-router/scripts/test_run_luna_worker.py`
- [x] `git diff --check`

The existing advisory warning that `skills/threads/SKILL.md` is 580 lines remains unchanged.