### PR TITLE
feat(sol-luna-router): attribute verified task costs

### DIFF
--- a/skills/sol-luna-router/SKILL.md
+++ b/skills/sol-luna-router/SKILL.md
@@ -138,6 +138,52 @@ Treat the report as observational evidence. Its token totals cover Luna only, no
 commander. Use comparable task cohorts or controlled A/B benchmarks that include both agents
 before claiming that routing caused an efficiency improvement.
 
+### Optional historical credit estimate
+
+Credit estimation is opt-in. Without `--rate-card`, the analyzer does not estimate credits and keeps
+the existing token-only report behavior. The bundled card is a dated benchmark assumption, not
+current pricing:
+
+```bash
+python3 <skill-dir>/scripts/analyze_run_log.py \
+  --run-log /absolute/private/runs.jsonl \
+  --rate-card <skill-dir>/references/rate-card-2026-08-05.json \
+  --format json
+```
+
+The card calculates Luna worker credits from `input_tokens`,
+`cached_input_tokens`, and `output_tokens`; `input_tokens` includes cached input, so uncached input
+is the difference. Every run, including failed runs, is costed when it has exact valid usage.
+Missing usage is unresolved rather than zero; malformed, negative, or inconsistent supplied usage
+is excluded and reported as unresolved. Worker-only normalized metrics are null when worker usage
+coverage is incomplete.
+`gpt-5.6-luna` remains fixed at max reasoning; the estimate does not change routing or reasoning.
+
+Joining Sol commander usage is a separate explicit opt-in and reads only parent IDs already present
+in the ledger:
+
+```bash
+python3 <skill-dir>/scripts/analyze_run_log.py \
+  --run-log /absolute/private/runs.jsonl \
+  --rate-card <skill-dir>/references/rate-card-2026-08-05.json \
+  --codex-sessions-root /absolute/private/.codex/sessions \
+  --format json
+```
+
+The join reads only session metadata, token-count event timestamps/types, and cumulative token
+usage. For the union of each parent’s merged run windows, it subtracts the last snapshot at or
+before each window start from the first snapshot at or after its end. It never copies prompt,
+response, or raw event text into the report or ledger. Sol preflight before the first run start and
+work after the last run completion are outside this attribution window. Shared parent windows are
+charged once; missing baselines/endpoints, counter resets, malformed data, missing sessions, and
+ambiguous files remain visible as unresolved coverage. Resolved partial commander components may
+be shown, but commander-plus-worker totals and total-scope normalized metrics are null until every
+required parent window resolves. A complete total additionally requires every ledger run to have
+valid worker usage; commander-window coverage alone is insufficient. The runner preserves exact
+usage on failed Codex exits or failed turns when Codex emitted it, but absent usage remains
+unresolved. The normalized credit metrics are observational cost-per-outcome measures; controlled
+A/B remains the causal total-cost proof.
+
 ### 5. Request a correction
 
 When verification or Sol review finds an actionable defect, write a new temporary prompt containing

--- a/skills/sol-luna-router/references/rate-card-2026-08-05.json
+++ b/skills/sol-luna-router/references/rate-card-2026-08-05.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": 1,
+  "id": "sol-luna-credits-2026-08-05",
+  "as_of": "2026-08-05",
+  "label": "historical benchmark estimate",
+  "not_current_pricing": true,
+  "units": {
+    "currency": "credits",
+    "token_basis": "per_1m_tokens"
+  },
+  "model_mapping": {
+    "sol": "gpt-5.6-sol",
+    "luna": "gpt-5.6-luna"
+  },
+  "rates": {
+    "gpt-5.6-sol": {
+      "uncached_input": 125,
+      "cached_input": 12.5,
+      "output": 750
+    },
+    "gpt-5.6-luna": {
+      "uncached_input": 5,
+      "cached_input": 0.5,
+      "output": 30
+    }
+  }
+}

--- a/skills/sol-luna-router/references/run-log.md
+++ b/skills/sol-luna-router/references/run-log.md
@@ -40,9 +40,10 @@ delete them according to the user's retention policy.
 
 ## Fields and interpretation
 
-`status` is `success` or `failed`. Successful records include the exact non-negative integer token
-fields emitted by Codex under `usage`; the runner does not estimate billing or infer prices.
-Failures include a stable `failure_code` and exclude raw error messages. Important codes include:
+`status` is `success` or `failed`. Run records include the exact normalized token fields emitted by
+Codex under `usage` when available, including on a failed exit or failed turn; absent usage is not
+written as zero. The runner does not estimate billing or infer prices. Failures include a stable
+`failure_code` and exclude raw error messages. Important codes include:
 
 - `capacity_exhausted`: rate, quota, usage, credit, or spend capacity prevented completion;
 - `timeout`: the bounded worker runtime expired;
@@ -71,9 +72,63 @@ The report separates three questions:
   median duration, and p95 duration.
 
 Token fields come from the Luna worker event stream. They do not include Sol commander tokens, so
-they measure worker efficiency rather than total routed-task cost. The `parent_session_id` is kept
-for a later authorized join with parent-session analytics; the local ledger does not read or copy
-the parent transcript.
+the default report measures worker efficiency rather than total routed-task cost. The
+`parent_session_id` is kept for a later authorized join with parent-session analytics; the local
+ledger does not read or copy the parent transcript.
+
+## Historical credit estimates
+
+Credit estimation is deliberately opt-in. Add the bundled machine-readable card when a dated
+benchmark estimate is wanted:
+
+```bash
+python3 <skill-dir>/scripts/analyze_run_log.py \
+  --run-log /absolute/private/runs.jsonl \
+  --rate-card <skill-dir>/references/rate-card-2026-08-05.json \
+  --format json
+```
+
+The card is labeled `historical benchmark estimate`, has `as_of` `2026-08-05`, and must not be
+described as current pricing. Its units are credits per 1M tokens. Luna cost uses exact integer
+`input_tokens`, `cached_input_tokens`, and `output_tokens`; cached input is included in input, and
+uncached input is `input_tokens - cached_input_tokens`. Every run, including failed runs, is
+costed only when exact valid usage exists. Missing usage is unresolved rather than zero; malformed,
+negative, or inconsistent usage is excluded and reported under worker unresolved-usage reasons.
+The report exposes `worker_runs_total`, `worker_runs_costed`, `worker_runs_unresolved`,
+`worker_cost_coverage`, `worker_estimate_complete`, and partial worker credits.
+
+The worker-only normalized fields are null when worker usage coverage is incomplete. The total-scope
+fields `credits_per_verified_run`, `credits_per_first_pass_verified_run`, and
+`commander_credit_share` require both complete worker coverage and complete commander-window
+coverage. With no join, complete worker-only metrics may be reported under the explicit
+`worker_only` scope; a commander-plus-worker total is never inferred.
+
+## Explicit parent-session join
+
+Commander usage remains off unless a caller supplies a local Codex sessions root:
+
+```bash
+python3 <skill-dir>/scripts/analyze_run_log.py \
+  --run-log /absolute/private/runs.jsonl \
+  --rate-card <skill-dir>/references/rate-card-2026-08-05.json \
+  --codex-sessions-root /absolute/private/.codex/sessions \
+  --format json
+```
+
+The analyzer resolves only unique, non-empty `parent_session_id` values from the ledger. It assumes
+the matching rollout JSONL has a `session_meta` record with `payload.id`, and later
+`event_msg`/`payload.type == "token_count"` records with top-level `timestamp` and
+`payload.info.total_token_usage`. It strictly parses ledger `started_at`/`completed_at` and event
+timestamps, merges overlapping run windows per parent, then subtracts the last cumulative snapshot
+at or before each merged window start from the first snapshot at or after its end. It uses only
+token metadata, never prompt/response text. The report makes shared-window de-duplication, missing
+baselines/endpoints, counter decreases/resets, malformed files or usage, ambiguous duplicate
+matches, and unique-ID / run-reference / window coverage visible. Sol preflight before run start
+and work after run completion are outside the commander-window attribution. Resolved partial
+commander components may be shown, but commander-plus-worker totals and total-scope normalized
+metrics are null until every required parent window resolves. Complete total attribution also
+requires every ledger run to have valid worker usage. Failed runs with exact usage are included;
+failed runs without usage remain unresolved. Controlled A/B remains the causal total-cost proof.
 
 Multiple annotations for one run are allowed because the ledger is append-only; the latest
 annotation wins and `evaluation_overwrites` makes revisions visible. Orphan annotations and

--- a/skills/sol-luna-router/scripts/analyze_run_log.py
+++ b/skills/sol-luna-router/scripts/analyze_run_log.py
@@ -5,12 +5,44 @@ from __future__ import annotations
 
 import argparse
 from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from decimal import Decimal, InvalidOperation
 import json
+import math
 from pathlib import Path
+import re
 import statistics
 import sys
 
 from run_luna_worker import default_run_log_path
+
+
+TOKEN_FIELDS = ("input_tokens", "cached_input_tokens", "output_tokens")
+RATE_FIELDS = ("uncached_input", "cached_input", "output")
+ONE_MILLION = Decimal(1_000_000)
+ISO_TIMESTAMP_RE = re.compile(
+    r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}"
+    r"(?:\.\d{1,6})?(?:Z|[+-]\d{2}:\d{2})$"
+)
+
+
+@dataclass(frozen=True)
+class TimeWindow:
+    start: datetime
+    end: datetime
+
+
+@dataclass(frozen=True)
+class TokenSnapshot:
+    timestamp: datetime
+    usage: dict[str, int]
+
+
+@dataclass
+class ParentSessionFile:
+    snapshots: list[TokenSnapshot]
+    errors: Counter[str]
 
 
 def _ratio(numerator: int, denominator: int) -> float | None:
@@ -55,7 +87,658 @@ def read_records(path: Path) -> list[dict[str, object]]:
     return records
 
 
-def summarize(path: Path) -> dict[str, object]:
+def _required_string(value: object, field: str, context: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{context}: {field} must be a non-empty string")
+    return value
+
+
+def _rate_value(value: object, field: str, context: str) -> Decimal:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{context}: {field} must be a non-negative number")
+    try:
+        parsed = Decimal(str(value))
+    except (InvalidOperation, ValueError) as error:
+        raise ValueError(f"{context}: {field} must be a non-negative number") from error
+    if not parsed.is_finite() or parsed < 0:
+        raise ValueError(f"{context}: {field} must be a non-negative number")
+    return parsed
+
+
+def load_rate_card(path: Path) -> dict[str, object]:
+    context = f"rate card {path}"
+    try:
+        with path.open(encoding="utf-8") as handle:
+            card = json.load(handle)
+    except json.JSONDecodeError as error:
+        raise ValueError(f"{context}: invalid JSON: {error.msg}") from error
+    except UnicodeDecodeError as error:
+        raise ValueError(f"{context}: invalid UTF-8") from error
+    if not isinstance(card, dict):
+        raise ValueError(f"{context}: top-level value must be an object")
+
+    schema_version = card.get("schema_version")
+    if not isinstance(schema_version, int) or isinstance(schema_version, bool) or schema_version < 1:
+        raise ValueError(f"{context}: schema_version must be a positive integer")
+    card_id = _required_string(card.get("id"), "id", context)
+    as_of = _required_string(card.get("as_of"), "as_of", context)
+    label = _required_string(card.get("label"), "label", context)
+    if "historical" not in label.lower() and "estimate" not in label.lower():
+        raise ValueError(f"{context}: label must identify a historical estimate")
+    if card.get("not_current_pricing") is not True:
+        raise ValueError(f"{context}: not_current_pricing must be true")
+
+    units = card.get("units")
+    if not isinstance(units, dict):
+        raise ValueError(f"{context}: units must be an object")
+    if units.get("currency") != "credits" or units.get("token_basis") != "per_1m_tokens":
+        raise ValueError(
+            f"{context}: units must declare credits and per_1m_tokens"
+        )
+
+    model_mapping = card.get("model_mapping")
+    if not isinstance(model_mapping, dict):
+        raise ValueError(f"{context}: model_mapping must be an object")
+    mapped_models: dict[str, str] = {}
+    for role in ("sol", "luna"):
+        mapped_models[role] = _required_string(model_mapping.get(role), role, context)
+
+    rates = card.get("rates")
+    if not isinstance(rates, dict):
+        raise ValueError(f"{context}: rates must be an object")
+    parsed_rates: dict[str, dict[str, Decimal]] = {}
+    for role, model in mapped_models.items():
+        model_rates = rates.get(model)
+        if not isinstance(model_rates, dict):
+            raise ValueError(f"{context}: missing rates for model {model}")
+        parsed_rates[role] = {
+            field: _rate_value(model_rates.get(field), field, f"{context} model {model}")
+            for field in RATE_FIELDS
+        }
+
+    return {
+        "schema_version": schema_version,
+        "id": card_id,
+        "as_of": as_of,
+        "label": label,
+        "not_current_pricing": True,
+        "units": units,
+        "model_mapping": mapped_models,
+        "_rates": parsed_rates,
+        "source": str(path.resolve()),
+    }
+
+
+def _strict_usage(usage: object, context: str) -> dict[str, int]:
+    if not isinstance(usage, dict):
+        raise ValueError(f"{context}: usage must be an object")
+
+    parsed: dict[str, int] = {}
+    for field in TOKEN_FIELDS:
+        value = usage.get(field)
+        if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+            raise ValueError(f"{context}: {field} must be a non-negative integer")
+        parsed[field] = value
+
+    if parsed["cached_input_tokens"] > parsed["input_tokens"]:
+        raise ValueError(
+            f"{context}: cached_input_tokens cannot exceed input_tokens"
+        )
+
+    for field, value in usage.items():
+        if isinstance(field, str) and field.endswith("_tokens"):
+            if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+                raise ValueError(f"{context}: {field} must be a non-negative integer")
+            parsed[field] = value
+    return parsed
+
+
+def _json_number(value: Decimal) -> int | float:
+    if not value.is_finite():
+        raise ValueError("estimated credits must be finite")
+    if value == value.to_integral_value():
+        return int(value)
+    as_float = float(value)
+    if not math.isfinite(as_float):
+        raise ValueError("estimated credits exceed JSON number range")
+    return as_float
+
+
+def _usage_credits(usage: object, rates: dict[str, Decimal], context: str) -> Decimal:
+    parsed = _strict_usage(usage, context)
+    uncached_input_tokens = parsed["input_tokens"] - parsed["cached_input_tokens"]
+    return (
+        Decimal(uncached_input_tokens) * rates["uncached_input"]
+        + Decimal(parsed["cached_input_tokens"]) * rates["cached_input"]
+        + Decimal(parsed["output_tokens"]) * rates["output"]
+    ) / ONE_MILLION
+
+
+def _parse_timestamp(value: object, field: str, context: str) -> datetime:
+    if not isinstance(value, str) or not value or not ISO_TIMESTAMP_RE.fullmatch(value):
+        raise ValueError(f"{context}: {field} must be an ISO-8601 timestamp")
+    normalized = value[:-1] + "+00:00" if value.endswith("Z") else value
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError as error:
+        raise ValueError(f"{context}: {field} must be an ISO-8601 timestamp") from error
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValueError(f"{context}: {field} must include a timezone")
+    return parsed.astimezone(timezone.utc)
+
+
+def _session_id_from_record(record: dict[str, object]) -> str | None:
+    payload = record.get("payload")
+    if isinstance(payload, dict):
+        for field in ("id", "session_id"):
+            candidate = payload.get(field)
+            if isinstance(candidate, str) and candidate:
+                return candidate
+    for field in ("session_id", "id"):
+        candidate = record.get(field)
+        if isinstance(candidate, str) and candidate:
+            return candidate
+    return None
+
+
+def _token_count_payload(event: dict[str, object]) -> dict[str, object] | None:
+    payload = event.get("payload")
+    if isinstance(payload, dict) and payload.get("type") == "token_count":
+        return payload
+    if event.get("type") == "token_count":
+        return event
+    return None
+
+
+def _parent_total_usage(event: dict[str, object], context: str) -> object | None:
+    token_count = _token_count_payload(event)
+    if token_count is None:
+        return None
+    info = token_count.get("info")
+    if not isinstance(info, dict):
+        raise ValueError(f"{context}: token_count info must be an object")
+    if "total_token_usage" not in info:
+        raise ValueError(f"{context}: token_count has no total_token_usage")
+    return info["total_token_usage"]
+
+
+def _find_parent_sessions(
+    root: Path, target_ids: set[str]
+) -> tuple[dict[str, list[ParentSessionFile]], int, int]:
+    if not root.is_dir():
+        raise ValueError(f"Codex sessions root is not a directory: {root}")
+
+    candidates: dict[str, list[ParentSessionFile]] = {}
+    files_scanned = 0
+    malformed_files = 0
+    for path in sorted(root.rglob("*.jsonl"), key=lambda item: str(item)):
+        if not path.is_file():
+            continue
+        files_scanned += 1
+        session_id: str | None = None
+        session: ParentSessionFile | None = None
+        try:
+            with path.open(encoding="utf-8") as handle:
+                first_line = handle.readline()
+                if not first_line.strip():
+                    continue
+                try:
+                    first_record = json.loads(first_line)
+                except json.JSONDecodeError:
+                    malformed_files += 1
+                    continue
+                if not isinstance(first_record, dict):
+                    malformed_files += 1
+                    continue
+                session_id = _session_id_from_record(first_record)
+                if session_id not in target_ids:
+                    continue
+
+                session = ParentSessionFile([], Counter())
+
+                def consume_event(event: dict[str, object], line_number: int) -> None:
+                    if _token_count_payload(event) is None:
+                        return
+                    context = f"{path}:{line_number}"
+                    try:
+                        timestamp = _parse_timestamp(
+                            event.get("timestamp"), "timestamp", context
+                        )
+                    except ValueError:
+                        session.errors["malformed_parent_timestamp"] += 1
+                        return
+                    try:
+                        usage = _strict_usage(
+                            _parent_total_usage(event, context), context
+                        )
+                    except ValueError:
+                        session.errors["malformed_token_usage"] += 1
+                        return
+                    session.snapshots.append(TokenSnapshot(timestamp, usage))
+
+                consume_event(first_record, 1)
+                for line_number, raw_line in enumerate(handle, start=2):
+                    if not raw_line.strip():
+                        continue
+                    try:
+                        event = json.loads(raw_line)
+                    except json.JSONDecodeError:
+                        session.errors["malformed_session_jsonl"] += 1
+                        malformed_files += 1
+                        continue
+                    if not isinstance(event, dict):
+                        session.errors["malformed_session_jsonl"] += 1
+                        malformed_files += 1
+                        continue
+                    consume_event(event, line_number)
+        except UnicodeDecodeError:
+            malformed_files += 1
+            if session is not None:
+                session.errors["malformed_session_encoding"] += 1
+        if session_id in target_ids and session is not None:
+            candidates.setdefault(session_id, []).append(session)
+    return candidates, files_scanned, malformed_files
+
+
+def _parent_references(
+    run_values: list[dict[str, object]],
+) -> Counter[str]:
+    references: Counter[str] = Counter()
+    for record in run_values:
+        parent_session_id = record.get("parent_session_id")
+        if isinstance(parent_session_id, str) and parent_session_id:
+            references[parent_session_id] += 1
+    return references
+
+
+def _merge_windows(windows: list[TimeWindow]) -> list[TimeWindow]:
+    if not windows:
+        return []
+    ordered = sorted(windows, key=lambda window: (window.start, window.end))
+    merged: list[TimeWindow] = [ordered[0]]
+    for window in ordered[1:]:
+        current = merged[-1]
+        if window.start <= current.end:
+            merged[-1] = TimeWindow(current.start, max(current.end, window.end))
+        else:
+            merged.append(window)
+    return merged
+
+
+def _build_parent_windows(
+    run_values: list[dict[str, object]],
+) -> tuple[Counter[str], dict[str, list[TimeWindow]], dict[str, Counter[str]]]:
+    references = _parent_references(run_values)
+    raw_windows: dict[str, list[TimeWindow]] = {
+        session_id: [] for session_id in references
+    }
+    invalid_windows: Counter[str] = Counter()
+    invalid_reasons: dict[str, Counter[str]] = {
+        session_id: Counter() for session_id in references
+    }
+    for record in run_values:
+        session_id = record.get("parent_session_id")
+        if not isinstance(session_id, str) or not session_id:
+            continue
+        context = f"run {record.get('run_id', '<unknown>')}"
+        try:
+            start = _parse_timestamp(record.get("started_at"), "started_at", context)
+            end = _parse_timestamp(record.get("completed_at"), "completed_at", context)
+        except ValueError:
+            invalid_windows[session_id] += 1
+            if record.get("started_at") is None or record.get("completed_at") is None:
+                invalid_reasons[session_id]["missing_ledger_timestamp"] += 1
+            else:
+                invalid_reasons[session_id]["malformed_ledger_timestamp"] += 1
+            continue
+        if end < start:
+            invalid_windows[session_id] += 1
+            invalid_reasons[session_id]["invalid_ledger_window"] += 1
+            continue
+        raw_windows[session_id].append(TimeWindow(start, end))
+    return (
+        invalid_windows,
+        {
+            session_id: _merge_windows(windows)
+            for session_id, windows in raw_windows.items()
+        },
+        invalid_reasons,
+    )
+
+
+def _usage_delta(
+    baseline: TokenSnapshot, endpoint: TokenSnapshot, context: str
+) -> dict[str, int]:
+    delta: dict[str, int] = {}
+    for field in TOKEN_FIELDS:
+        difference = endpoint.usage[field] - baseline.usage[field]
+        if difference < 0:
+            raise ValueError(f"{context}: cumulative token counter decreased or reset")
+        delta[field] = difference
+    if delta["cached_input_tokens"] > delta["input_tokens"]:
+        raise ValueError(f"{context}: cumulative input counter is inconsistent")
+    return delta
+
+
+def _session_has_counter_reset(snapshots: list[TokenSnapshot]) -> bool:
+    ordered = sorted(snapshots, key=lambda snapshot: snapshot.timestamp)
+    return any(
+        current.usage[field] < previous.usage[field]
+        for previous, current in zip(ordered, ordered[1:])
+        for field in TOKEN_FIELDS
+    )
+
+
+def _disabled_parent_join(run_values: list[dict[str, object]]) -> dict[str, object]:
+    references = _parent_references(run_values)
+    shared = sum(count > 1 for count in references.values())
+    duplicates = sum(count - 1 for count in references.values() if count > 1)
+    return {
+        "schema_version": 1,
+        "enabled": False,
+        "reason": "codex_sessions_root_not_supplied",
+        "ledger_parent_sessions": len(references),
+        "ledger_run_references": sum(references.values()),
+        "shared_parent_sessions": shared,
+        "duplicate_parent_references": duplicates,
+    }
+
+
+def _join_parent_sessions(
+    run_values: list[dict[str, object]], root: Path
+) -> tuple[dict[str, object], list[dict[str, int]]]:
+    references = _parent_references(run_values)
+    target_ids = set(references)
+    candidates, files_scanned, malformed_files = _find_parent_sessions(root, target_ids)
+    invalid_windows, windows_by_parent, invalid_reasons = _build_parent_windows(run_values)
+    unresolved: Counter[str] = Counter()
+    resolved_window_usage: list[dict[str, int]] = []
+    required_windows = sum(
+        invalid_windows[session_id] + len(windows_by_parent[session_id])
+        for session_id in target_ids
+    )
+    resolved_windows = 0
+    matched_session_ids: set[str] = set()
+    resolved_parents: set[str] = set()
+    unresolved_parents: set[str] = set()
+    missing_parent_sessions = 0
+    ambiguous_parent_sessions = 0
+    missing_usage_parent_sessions = 0
+
+    for session_id in sorted(target_ids):
+        session_windows = windows_by_parent[session_id]
+        parent_unresolved = invalid_windows[session_id] > 0
+        for reason, count in invalid_reasons[session_id].items():
+            unresolved[reason] += count
+        session_candidates = candidates.get(session_id, [])
+        session: ParentSessionFile | None = None
+        if not session_candidates:
+            missing_parent_sessions += 1
+            unresolved["missing_parent_session"] += len(session_windows)
+            parent_unresolved = True
+        elif len(session_candidates) > 1:
+            ambiguous_parent_sessions += 1
+            unresolved["ambiguous_session_file"] += len(session_windows)
+            parent_unresolved = True
+        else:
+            matched_session_ids.add(session_id)
+            session = session_candidates[0]
+
+        if session is not None:
+            for reason, count in session.errors.items():
+                unresolved[reason] += count
+            if session.errors:
+                parent_unresolved = True
+            elif not session.snapshots:
+                missing_usage_parent_sessions += 1
+                unresolved["missing_baseline"] += len(session_windows)
+                unresolved["missing_endpoint"] += len(session_windows)
+                parent_unresolved = True
+            elif _session_has_counter_reset(session.snapshots):
+                unresolved["counter_decrease_or_reset"] += len(session_windows)
+                parent_unresolved = True
+            else:
+                snapshots = sorted(session.snapshots, key=lambda snapshot: snapshot.timestamp)
+                for window in session_windows:
+                    baseline_candidates = [
+                        snapshot
+                        for snapshot in snapshots
+                        if snapshot.timestamp <= window.start
+                    ]
+                    endpoint_candidates = [
+                        snapshot
+                        for snapshot in snapshots
+                        if snapshot.timestamp >= window.end
+                    ]
+                    if not baseline_candidates:
+                        unresolved["missing_baseline"] += 1
+                        parent_unresolved = True
+                        continue
+                    if not endpoint_candidates:
+                        unresolved["missing_endpoint"] += 1
+                        parent_unresolved = True
+                        continue
+                    try:
+                        resolved_window_usage.append(
+                            _usage_delta(
+                                baseline_candidates[-1],
+                                endpoint_candidates[0],
+                                f"parent session {session_id}",
+                            )
+                        )
+                    except ValueError:
+                        unresolved["counter_decrease_or_reset"] += 1
+                        parent_unresolved = True
+                        continue
+                    resolved_windows += 1
+
+        if parent_unresolved:
+            unresolved_parents.add(session_id)
+        else:
+            resolved_parents.add(session_id)
+
+    matched_references = sum(references[session_id] for session_id in resolved_parents)
+    token_totals: Counter[str] = Counter()
+    for usage in resolved_window_usage:
+        for field, value in usage.items():
+            if field.endswith("_tokens"):
+                token_totals[field] += value
+
+    total_parent_sessions = len(target_ids)
+    total_references = sum(references.values())
+    shared = sum(count > 1 for count in references.values())
+    duplicates = sum(count - 1 for count in references.values() if count > 1)
+    join = {
+        "schema_version": 1,
+        "enabled": True,
+        "ledger_parent_sessions": total_parent_sessions,
+        "ledger_run_references": total_references,
+        "shared_parent_sessions": shared,
+        "duplicate_parent_references": duplicates,
+        "session_files_scanned": files_scanned,
+        "malformed_session_files": malformed_files,
+        "matched_parent_sessions": len(matched_session_ids),
+        "resolved_parent_sessions": len(resolved_parents),
+        "missing_parent_sessions": missing_parent_sessions,
+        "ambiguous_parent_sessions": ambiguous_parent_sessions,
+        "missing_usage_parent_sessions": missing_usage_parent_sessions,
+        "required_parent_windows": required_windows,
+        "resolved_parent_windows": resolved_windows,
+        "unresolved_parent_windows": required_windows - resolved_windows,
+        "unresolved_parent_sessions": len(unresolved_parents),
+        "all_parent_windows_resolved": required_windows == resolved_windows,
+        "parent_session_coverage": _ratio(len(resolved_parents), total_parent_sessions),
+        "parent_window_coverage": _ratio(resolved_windows, required_windows),
+        "run_reference_coverage": _ratio(matched_references, total_references),
+        "attribution_scope": "union_of_merged_run_windows",
+        "preflight_before_run_start_excluded": True,
+        "post_completion_after_run_end_excluded": True,
+        "unresolved_by_reason": dict(sorted(unresolved.items())),
+        "commander_window_token_totals": dict(sorted(token_totals.items())),
+    }
+    return join, resolved_window_usage
+
+
+def _rate_values(rate_card: dict[str, object], role: str) -> dict[str, Decimal]:
+    rates = rate_card.get("_rates")
+    if not isinstance(rates, dict):
+        raise ValueError("rate card internal rates are missing")
+    role_rates = rates.get(role)
+    if not isinstance(role_rates, dict):
+        raise ValueError(f"rate card rates are missing for {role}")
+    return role_rates
+
+
+def _rate_card_metadata(rate_card: dict[str, object]) -> dict[str, object]:
+    return {
+        "schema_version": rate_card["schema_version"],
+        "id": rate_card["id"],
+        "as_of": rate_card["as_of"],
+        "label": rate_card["label"],
+        "historical_estimate": True,
+        "not_current_pricing": True,
+        "units": rate_card["units"],
+        "model_mapping": rate_card["model_mapping"],
+        "source": rate_card["source"],
+    }
+
+
+def _worker_usage_reason(usage: object) -> str:
+    if not isinstance(usage, dict):
+        return "missing_usage"
+    values = {field: usage.get(field) for field in TOKEN_FIELDS}
+    if any(isinstance(value, int) and not isinstance(value, bool) and value < 0 for value in values.values()):
+        return "negative_usage"
+    input_tokens = values["input_tokens"]
+    cached_input_tokens = values["cached_input_tokens"]
+    if (
+        isinstance(input_tokens, int)
+        and not isinstance(input_tokens, bool)
+        and isinstance(cached_input_tokens, int)
+        and not isinstance(cached_input_tokens, bool)
+        and cached_input_tokens > input_tokens
+    ):
+        return "inconsistent_usage"
+    return "malformed_usage"
+
+
+def _estimate_cost(
+    path: Path,
+    runs: list[dict[str, object]],
+    rate_card: dict[str, object],
+    join: dict[str, object] | None,
+    commander_window_usage: list[dict[str, int]],
+) -> tuple[dict[str, object], Decimal, Decimal | None, Decimal | None, bool]:
+    worker_model = rate_card["model_mapping"]["luna"]
+    worker_rates = _rate_values(rate_card, "luna")
+    worker_credits = Decimal(0)
+    worker_runs_costed = 0
+    worker_unresolved_reasons: Counter[str] = Counter()
+    for index, record in enumerate(runs, start=1):
+        model = record.get("model")
+        if model is not None and model != worker_model:
+            raise ValueError(
+                f"{path}: worker run {index} has model {model!r}, "
+                f"expected {worker_model!r} for the Luna rate card"
+            )
+        usage = record.get("usage")
+        try:
+            worker_credits += _usage_credits(
+                usage,
+                worker_rates,
+                f"{path}: worker run {index}",
+            )
+        except ValueError:
+            worker_unresolved_reasons[_worker_usage_reason(usage)] += 1
+            continue
+        worker_runs_costed += 1
+
+    worker_runs_total = len(runs)
+    worker_runs_unresolved = worker_runs_total - worker_runs_costed
+    worker_estimate_complete = worker_runs_unresolved == 0
+
+    commander_window_credits: Decimal | None = None
+    total_credits: Decimal | None = None
+    total_estimate_complete = False
+    commander_window_estimate_complete = False
+    if join is not None and join.get("enabled") is True:
+        commander_rates = _rate_values(rate_card, "sol")
+        commander_window_credits = Decimal(0)
+        for usage in commander_window_usage:
+            commander_window_credits += _usage_credits(
+                usage,
+                commander_rates,
+                f"{path}: joined commander window",
+            )
+        commander_window_estimate_complete = (
+            join.get("all_parent_windows_resolved") is True
+        )
+        total_estimate_complete = (
+            worker_estimate_complete and commander_window_estimate_complete
+        )
+        if total_estimate_complete:
+            total_credits = worker_credits + commander_window_credits
+            estimate_scope = "worker_plus_commander_window"
+        else:
+            estimate_scope = "worker_plus_resolved_commander_window_partial"
+    else:
+        estimate_scope = "worker_only"
+
+    cost = {
+        "schema_version": 1,
+        "estimate": True,
+        "estimate_scope": estimate_scope,
+        "total_estimate_complete": total_estimate_complete,
+        "rate_card": _rate_card_metadata(rate_card),
+        "worker_model": worker_model,
+        "commander_model": rate_card["model_mapping"]["sol"],
+        "commander_attribution": "merged_run_window_delta",
+        "worker_runs_total": worker_runs_total,
+        "worker_runs_costed": worker_runs_costed,
+        "worker_runs_unresolved": worker_runs_unresolved,
+        "worker_cost_coverage": _ratio(worker_runs_costed, worker_runs_total),
+        "worker_estimate_complete": worker_estimate_complete,
+        "worker_unresolved_usage_reasons": dict(sorted(worker_unresolved_reasons.items())),
+        "worker_credits": _json_number(worker_credits),
+        "worker_only_credits": _json_number(worker_credits),
+        "commander_sessions_costed": (
+            join.get("resolved_parent_sessions")
+            if commander_window_credits is not None and isinstance(join, dict)
+            else None
+        ),
+        "commander_windows_costed": (
+            len(commander_window_usage) if commander_window_credits is not None else None
+        ),
+        "commander_window_credits": (
+            _json_number(commander_window_credits)
+            if commander_window_credits is not None
+            else None
+        ),
+        "commander_credits": (
+            _json_number(commander_window_credits)
+            if commander_window_credits is not None
+            else None
+        ),
+        "total_credits": (
+            _json_number(total_credits) if total_credits is not None else None
+        ),
+        "commander_window_estimate_complete": commander_window_estimate_complete,
+    }
+    return (
+        cost,
+        worker_credits,
+        commander_window_credits,
+        total_credits,
+        total_estimate_complete,
+    )
+
+
+def summarize(
+    path: Path,
+    *,
+    rate_card_path: Path | None = None,
+    codex_sessions_root: Path | None = None,
+) -> dict[str, object]:
     records = read_records(path)
     runs: dict[str, dict[str, object]] = {}
     latest_evaluations: dict[str, dict[str, object]] = {}
@@ -141,7 +824,32 @@ def summarize(path: Path) -> dict[str, object]:
     checks_failed = sum(_integer(evaluation.get("checks_failed")) for evaluation in evaluated.values())
     warning_runs = sum(_integer(record.get("warning_count")) > 0 for record in successful)
 
-    return {
+    quality: dict[str, object] = {
+        "evaluated_runs": len(evaluated),
+        "evaluation_coverage": _ratio(len(evaluated), len(run_values)),
+        "evaluated_successful_runs": len(evaluated_successes),
+        "successful_evaluation_coverage": _ratio(
+            len(evaluated_successes), len(successful)
+        ),
+        "verified_runs": len(verified),
+        "verified_rate_among_evaluated_successes": _ratio(
+            len(verified), len(evaluated_successes)
+        ),
+        "verified_with_check_evidence": len(verified_with_checks),
+        "verified_check_evidence_coverage": _ratio(
+            len(verified_with_checks), len(verified)
+        ),
+        "initial_runs_evaluated": len(initial_evaluated),
+        "first_pass_verified_runs": len(first_pass_verified),
+        "first_pass_verified_rate": _ratio(
+            len(first_pass_verified), len(initial_evaluated)
+        ),
+        "outcomes": dict(sorted(outcomes.items())),
+        "checks_passed": checks_passed,
+        "checks_failed": checks_failed,
+    }
+
+    summary: dict[str, object] = {
         "schema_version": 1,
         "source": str(path),
         "source_exists": path.is_file(),
@@ -154,30 +862,7 @@ def summarize(path: Path) -> dict[str, object]:
             "warning_runs": warning_runs,
             "failure_codes": dict(sorted(failures.items())),
         },
-        "quality": {
-            "evaluated_runs": len(evaluated),
-            "evaluation_coverage": _ratio(len(evaluated), len(run_values)),
-            "evaluated_successful_runs": len(evaluated_successes),
-            "successful_evaluation_coverage": _ratio(
-                len(evaluated_successes), len(successful)
-            ),
-            "verified_runs": len(verified),
-            "verified_rate_among_evaluated_successes": _ratio(
-                len(verified), len(evaluated_successes)
-            ),
-            "verified_with_check_evidence": len(verified_with_checks),
-            "verified_check_evidence_coverage": _ratio(
-                len(verified_with_checks), len(verified)
-            ),
-            "initial_runs_evaluated": len(initial_evaluated),
-            "first_pass_verified_runs": len(first_pass_verified),
-            "first_pass_verified_rate": _ratio(
-                len(first_pass_verified), len(initial_evaluated)
-            ),
-            "outcomes": dict(sorted(outcomes.items())),
-            "checks_passed": checks_passed,
-            "checks_failed": checks_failed,
-        },
+        "quality": quality,
         "efficiency": {
             "token_scope": "luna_worker_only",
             "resume_runs": sum(record.get("command") == "resume" for record in run_values),
@@ -207,6 +892,91 @@ def summarize(path: Path) -> dict[str, object]:
         ),
     }
 
+    join: dict[str, object] | None = None
+    commander_window_usage: list[dict[str, int]] = []
+    if codex_sessions_root is not None:
+        join, commander_window_usage = _join_parent_sessions(
+            run_values, codex_sessions_root
+        )
+
+    if rate_card_path is not None:
+        rate_card = load_rate_card(rate_card_path)
+        if join is None:
+            join = _disabled_parent_join(run_values)
+        (
+            cost,
+            worker_credits,
+            commander_window_credits,
+            total_credits,
+            total_estimate_complete,
+        ) = _estimate_cost(
+            path,
+            run_values,
+            rate_card,
+            join,
+            commander_window_usage,
+        )
+        summary["cost"] = cost
+        quality["credit_scope"] = cost["estimate_scope"]
+        worker_normalized_credits = (
+            worker_credits if cost["worker_estimate_complete"] is True else None
+        )
+        quality["worker_credits_per_verified_run"] = (
+            _json_number(worker_normalized_credits / Decimal(len(verified)))
+            if worker_normalized_credits is not None and verified
+            else None
+        )
+        quality["worker_credits_per_first_pass_verified_run"] = (
+            _json_number(worker_normalized_credits / Decimal(len(first_pass_verified)))
+            if worker_normalized_credits is not None and first_pass_verified
+            else None
+        )
+        if join is None or join.get("enabled") is not True:
+            normalized_credits = worker_normalized_credits
+            normalized_scope = (
+                "worker_only"
+                if cost["worker_estimate_complete"] is True
+                else "incomplete_worker_usage_coverage"
+            )
+        elif total_estimate_complete and total_credits is not None:
+            normalized_credits = total_credits
+            normalized_scope = "worker_plus_commander_window"
+        else:
+            normalized_credits = None
+            worker_complete = cost["worker_estimate_complete"] is True
+            commander_complete = cost["commander_window_estimate_complete"] is True
+            if not worker_complete and not commander_complete:
+                normalized_scope = (
+                    "incomplete_worker_usage_and_commander_window_coverage"
+                )
+            elif not worker_complete:
+                normalized_scope = "incomplete_worker_usage_coverage"
+            else:
+                normalized_scope = "incomplete_commander_window_coverage"
+        quality["normalized_credit_scope"] = normalized_scope
+        quality["credits_per_verified_run"] = (
+            _json_number(normalized_credits / Decimal(len(verified)))
+            if normalized_credits is not None and verified
+            else None
+        )
+        quality["credits_per_first_pass_verified_run"] = (
+            _json_number(normalized_credits / Decimal(len(first_pass_verified)))
+            if normalized_credits is not None and first_pass_verified
+            else None
+        )
+        quality["commander_credit_share"] = (
+            _json_number(commander_window_credits / total_credits)
+            if total_estimate_complete
+            and commander_window_credits is not None
+            and total_credits
+            else None
+        )
+
+    if join is not None:
+        summary["parent_session_join"] = join
+
+    return summary
+
 
 def to_text(summary: dict[str, object]) -> str:
     reliability = summary["reliability"]
@@ -215,27 +985,66 @@ def to_text(summary: dict[str, object]) -> str:
     assert isinstance(reliability, dict)
     assert isinstance(quality, dict)
     assert isinstance(efficiency, dict)
-    return "\n".join(
-        [
-            "Sol-Luna evidence summary",
-            f"runs: {summary['runs_total']}",
-            f"success_rate: {reliability['success_rate']}",
-            f"evaluated_runs: {quality['evaluated_runs']}",
-            f"evaluation_coverage: {quality['evaluation_coverage']}",
-            f"verified_rate_among_evaluated_successes: {quality['verified_rate_among_evaluated_successes']}",
-            f"first_pass_verified_rate: {quality['first_pass_verified_rate']}",
-            f"verified_check_evidence_coverage: {quality['verified_check_evidence_coverage']}",
-            f"resume_runs: {efficiency['resume_runs']}",
-            f"median_duration_seconds: {efficiency['median_duration_seconds']}",
-            f"p95_duration_seconds: {efficiency['p95_duration_seconds']}",
-            f"claim_boundary: {summary['claim_boundary']}",
-        ]
-    ) + "\n"
+    lines = [
+        "Sol-Luna evidence summary",
+        f"runs: {summary['runs_total']}",
+        f"success_rate: {reliability['success_rate']}",
+        f"evaluated_runs: {quality['evaluated_runs']}",
+        f"evaluation_coverage: {quality['evaluation_coverage']}",
+        f"verified_rate_among_evaluated_successes: {quality['verified_rate_among_evaluated_successes']}",
+        f"first_pass_verified_rate: {quality['first_pass_verified_rate']}",
+        f"verified_check_evidence_coverage: {quality['verified_check_evidence_coverage']}",
+        f"resume_runs: {efficiency['resume_runs']}",
+        f"median_duration_seconds: {efficiency['median_duration_seconds']}",
+        f"p95_duration_seconds: {efficiency['p95_duration_seconds']}",
+    ]
+    cost = summary.get("cost")
+    if isinstance(cost, dict):
+        lines.extend(
+            [
+                f"estimate_scope: {cost['estimate_scope']}",
+                f"commander_attribution: {cost['commander_attribution']}",
+                f"worker_credits: {cost['worker_credits']}",
+                f"commander_window_credits: {cost['commander_window_credits']}",
+                f"total_credits: {cost['total_credits']}",
+                f"worker_credits_per_verified_run: {quality['worker_credits_per_verified_run']}",
+                f"worker_credits_per_first_pass_verified_run: {quality['worker_credits_per_first_pass_verified_run']}",
+                f"credits_per_verified_run: {quality['credits_per_verified_run']}",
+                f"credits_per_first_pass_verified_run: {quality['credits_per_first_pass_verified_run']}",
+                f"commander_credit_share: {quality['commander_credit_share']}",
+            ]
+        )
+    join = summary.get("parent_session_join")
+    if isinstance(join, dict) and join.get("enabled") is True:
+        lines.append(f"parent_session_coverage: {join['parent_session_coverage']}")
+        lines.append(f"parent_window_coverage: {join['parent_window_coverage']}")
+        lines.append(f"unresolved_parent_sessions: {join['unresolved_parent_sessions']}")
+    lines.append(f"claim_boundary: {summary['claim_boundary']}")
+    return "\n".join(lines) + "\n"
+
+
+def _absolute_optional_path(value: Path | None, option: str) -> Path | None:
+    if value is None:
+        return None
+    path = value.expanduser()
+    if not path.is_absolute():
+        raise ValueError(f"{option} must be absolute: {path}")
+    return path.resolve()
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--run-log", type=Path, help="JSONL ledger; defaults to the Luna run log.")
+    parser.add_argument(
+        "--rate-card",
+        type=Path,
+        help="Absolute JSON rate card for an explicit historical credit estimate.",
+    )
+    parser.add_argument(
+        "--codex-sessions-root",
+        type=Path,
+        help="Optional local Codex sessions root for an explicit parent-session join.",
+    )
     parser.add_argument("--format", choices=("text", "json"), default="text")
     args = parser.parse_args()
     path = args.run_log.expanduser() if args.run_log else default_run_log_path()
@@ -243,7 +1052,15 @@ def main() -> int:
         print(f"analyze_run_log.py: --run-log must be absolute: {path}", file=sys.stderr)
         return 1
     try:
-        summary = summarize(path.resolve())
+        rate_card_path = _absolute_optional_path(args.rate_card, "--rate-card")
+        sessions_root = _absolute_optional_path(
+            args.codex_sessions_root, "--codex-sessions-root"
+        )
+        summary = summarize(
+            path.resolve(),
+            rate_card_path=rate_card_path,
+            codex_sessions_root=sessions_root,
+        )
     except (OSError, ValueError) as error:
         print(f"analyze_run_log.py: {error}", file=sys.stderr)
         return 1

--- a/skills/sol-luna-router/scripts/run_luna_worker.py
+++ b/skills/sol-luna-router/scripts/run_luna_worker.py
@@ -479,6 +479,7 @@ def parse_events(stdout: str, stderr: str, returncode: int) -> dict[str, object]
     thread_id: str | None = None
     final_response: str | None = None
     usage: object = None
+    failure_usage: object = None
     completed = False
     fatal_error: str | None = None
     warnings: list[str] = []
@@ -504,6 +505,10 @@ def parse_events(stdout: str, stderr: str, returncode: int) -> dict[str, object]
             )
         events.append(event)
 
+        candidate_usage = event.get("usage")
+        if isinstance(candidate_usage, dict):
+            usage = candidate_usage
+
         event_type = event.get("type")
         if event_type == "thread.started":
             candidate = event.get("thread_id")
@@ -522,10 +527,15 @@ def parse_events(stdout: str, stderr: str, returncode: int) -> dict[str, object]
             usage = event.get("usage")
         elif event_type == "turn.failed":
             fatal_error = extract_error(event)
+            failure_usage = usage
         elif event_type == "error":
             warnings.append(extract_error(event))
 
     details = {"worker_thread_id": thread_id, "event_count": len(events)}
+    usage_for_failure = failure_usage if fatal_error is not None else usage
+    normalized_usage = normalize_usage(usage_for_failure)
+    if normalized_usage:
+        details["usage"] = normalized_usage
     if returncode != 0:
         detail = fatal_error or (warnings[-1] if warnings else None)
         detail = detail or stderr[-STDERR_TAIL_CHARS:] or "no error details"
@@ -799,6 +809,9 @@ def build_failure_record(
     )
     if isinstance(details.get("duration_seconds"), (int, float)):
         record["worker_duration_seconds"] = details["duration_seconds"]
+    usage = details.get("usage")
+    if isinstance(usage, dict) and usage:
+        record["usage"] = usage
     return record
 
 

--- a/skills/sol-luna-router/scripts/test_analyze_run_log.py
+++ b/skills/sol-luna-router/scripts/test_analyze_run_log.py
@@ -24,6 +24,8 @@ class AnalyzeRunLogTests(unittest.TestCase):
     def setUp(self) -> None:
         self.temp_dir = tempfile.TemporaryDirectory(prefix="sol-luna-analysis-test-")
         self.path = Path(self.temp_dir.name) / "runs.jsonl"
+        self.sessions_root = Path(self.temp_dir.name) / "sessions"
+        self.rate_card = SCRIPT.parent.parent / "references" / "rate-card-2026-08-05.json"
 
     def tearDown(self) -> None:
         self.temp_dir.cleanup()
@@ -33,6 +35,48 @@ class AnalyzeRunLogTests(unittest.TestCase):
             "".join(json.dumps(record) + "\n" for record in records),
             encoding="utf-8",
         )
+
+    def write_session(
+        self,
+        session_id: str,
+        *snapshots: dict[str, int] | tuple[str, dict[str, int]],
+        filename: str | None = None,
+    ) -> Path:
+        session_path = self.sessions_root / "2026" / "08" / "12" / (
+            filename or f"rollout-{session_id}.jsonl"
+        )
+        session_path.parent.mkdir(parents=True, exist_ok=True)
+        records: list[dict[str, object]] = [
+            {
+                "type": "session_meta",
+                "payload": {
+                    "id": session_id,
+                    "cwd": "/private/project",
+                    "instructions": "private prompt text must not appear in reports",
+                },
+            }
+        ]
+        for index, snapshot in enumerate(snapshots):
+            if isinstance(snapshot, tuple):
+                timestamp, usage = snapshot
+            else:
+                timestamp = f"2026-08-12T00:0{index}:00Z"
+                usage = snapshot
+            records.append(
+                {
+                    "timestamp": timestamp,
+                    "type": "event_msg",
+                    "payload": {
+                        "type": "token_count",
+                        "info": {"total_token_usage": usage},
+                    },
+                }
+            )
+        session_path.write_text(
+            "".join(json.dumps(record) + "\n" for record in records),
+            encoding="utf-8",
+        )
+        return session_path
 
     def test_summary_joins_latest_evaluation_and_reports_quality_cost(self) -> None:
         self.write_records(
@@ -108,6 +152,697 @@ class AnalyzeRunLogTests(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "invalid JSONL"):
             ANALYZER.summarize(self.path)
+
+    def test_worker_only_cost_uses_uncached_and_cached_input_separately(self) -> None:
+        self.write_records(
+            {
+                "record_type": "run",
+                "run_id": "run-cost",
+                "command": "run",
+                "status": "success",
+                "usage": {
+                    "input_tokens": 1_000_000,
+                    "cached_input_tokens": 200_000,
+                    "output_tokens": 100_000,
+                },
+            }
+        )
+
+        summary = ANALYZER.summarize(self.path, rate_card_path=self.rate_card)
+
+        cost = summary["cost"]
+        self.assertEqual(cost["worker_credits"], 7.1)
+        self.assertIsNone(cost["commander_credits"])
+        self.assertIsNone(cost["total_credits"])
+        self.assertEqual(cost["estimate_scope"], "worker_only")
+        self.assertTrue(cost["rate_card"]["historical_estimate"])
+        self.assertEqual(cost["rate_card"]["as_of"], "2026-08-05")
+
+    def test_failed_run_with_exact_usage_is_costed(self) -> None:
+        self.write_records(
+            {
+                "record_type": "run",
+                "run_id": "run-failed-with-usage",
+                "command": "run",
+                "status": "failed",
+                "failure_code": "codex_exit",
+                "usage": {
+                    "input_tokens": 1_000_000,
+                    "cached_input_tokens": 200_000,
+                    "output_tokens": 100_000,
+                },
+            }
+        )
+
+        summary = ANALYZER.summarize(self.path, rate_card_path=self.rate_card)
+
+        cost = summary["cost"]
+        self.assertEqual(cost["worker_runs_total"], 1)
+        self.assertEqual(cost["worker_runs_costed"], 1)
+        self.assertEqual(cost["worker_runs_unresolved"], 0)
+        self.assertEqual(cost["worker_cost_coverage"], 1.0)
+        self.assertTrue(cost["worker_estimate_complete"])
+        self.assertEqual(cost["worker_credits"], 7.1)
+
+    def test_failed_run_without_usage_makes_totals_and_normalized_metrics_incomplete(self) -> None:
+        usage = {
+            "input_tokens": 1_000_000,
+            "cached_input_tokens": 200_000,
+            "output_tokens": 100_000,
+        }
+        self.write_records(
+            {
+                "record_type": "run",
+                "run_id": "run-complete-worker",
+                "command": "run",
+                "status": "success",
+                "parent_session_id": "parent-worker-gap",
+                "started_at": "2026-08-12T10:00:00Z",
+                "completed_at": "2026-08-12T10:10:00Z",
+                "usage": usage,
+            },
+            {
+                "record_type": "run",
+                "run_id": "run-missing-worker",
+                "command": "run",
+                "status": "failed",
+                "failure_code": "codex_exit",
+                "parent_session_id": "parent-worker-gap",
+                "started_at": "2026-08-12T10:11:00Z",
+                "completed_at": "2026-08-12T10:20:00Z",
+            },
+            {
+                "record_type": "evaluation",
+                "run_id": "run-complete-worker",
+                "outcome": "verified",
+                "checks_passed": 1,
+                "checks_failed": 0,
+            },
+        )
+        self.write_session(
+            "parent-worker-gap",
+            (
+                "2026-08-12T09:59:00Z",
+                {"input_tokens": 100, "cached_input_tokens": 10, "output_tokens": 20},
+            ),
+            (
+                "2026-08-12T10:10:30Z",
+                {"input_tokens": 500, "cached_input_tokens": 50, "output_tokens": 60},
+            ),
+            (
+                "2026-08-12T10:21:00Z",
+                {
+                    "input_tokens": 1_000_100,
+                    "cached_input_tokens": 100_010,
+                    "output_tokens": 100_020,
+                },
+            ),
+        )
+
+        summary = ANALYZER.summarize(
+            self.path,
+            rate_card_path=self.rate_card,
+            codex_sessions_root=self.sessions_root,
+        )
+
+        cost = summary["cost"]
+        quality = summary["quality"]
+        self.assertEqual(cost["worker_runs_total"], 2)
+        self.assertEqual(cost["worker_runs_costed"], 1)
+        self.assertEqual(cost["worker_runs_unresolved"], 1)
+        self.assertEqual(cost["worker_cost_coverage"], 0.5)
+        self.assertFalse(cost["worker_estimate_complete"])
+        self.assertEqual(cost["worker_unresolved_usage_reasons"], {"missing_usage": 1})
+        self.assertEqual(cost["commander_window_credits"], 188.75)
+        self.assertIsNone(cost["total_credits"])
+        self.assertFalse(cost["total_estimate_complete"])
+        self.assertEqual(
+            quality["normalized_credit_scope"],
+            "incomplete_worker_usage_coverage",
+        )
+        self.assertIsNone(quality["worker_credits_per_verified_run"])
+        self.assertIsNone(quality["credits_per_verified_run"])
+        self.assertIsNone(quality["commander_credit_share"])
+
+    def test_parent_join_uses_bounded_window_delta_and_reports_separate_costs(self) -> None:
+        self.write_records(
+            {
+                "record_type": "run",
+                "run_id": "run-parent",
+                "command": "run",
+                "status": "success",
+                "parent_session_id": "parent-1",
+                "started_at": "2026-08-12T10:00:00Z",
+                "completed_at": "2026-08-12T10:10:00Z",
+                "usage": {
+                    "input_tokens": 1_000_000,
+                    "cached_input_tokens": 200_000,
+                    "output_tokens": 100_000,
+                },
+            }
+        )
+        self.write_session(
+            "parent-1",
+            (
+                "2026-08-12T09:59:00Z",
+                {"input_tokens": 100, "cached_input_tokens": 10, "output_tokens": 20},
+            ),
+            (
+                "2026-08-12T10:11:00Z",
+                {
+                    "input_tokens": 1_000_100,
+                    "cached_input_tokens": 100_010,
+                    "output_tokens": 100_020,
+                },
+            ),
+        )
+
+        summary = ANALYZER.summarize(
+            self.path,
+            rate_card_path=self.rate_card,
+            codex_sessions_root=self.sessions_root,
+        )
+
+        join = summary["parent_session_join"]
+        cost = summary["cost"]
+        self.assertEqual(join["matched_parent_sessions"], 1)
+        self.assertEqual(join["attribution_scope"], "union_of_merged_run_windows")
+        self.assertEqual(join["parent_session_coverage"], 1.0)
+        self.assertEqual(join["commander_window_token_totals"]["input_tokens"], 1_000_000)
+        self.assertEqual(cost["worker_credits"], 7.1)
+        self.assertEqual(cost["commander_credits"], 188.75)
+        self.assertEqual(cost["commander_window_credits"], 188.75)
+        self.assertEqual(cost["total_credits"], 195.85)
+        self.assertTrue(cost["total_estimate_complete"])
+        self.assertAlmostEqual(summary["quality"]["commander_credit_share"], 188.75 / 195.85)
+
+    def test_shared_parent_is_counted_once_and_duplicate_references_are_visible(self) -> None:
+        usage = {
+            "input_tokens": 1_000_000,
+            "cached_input_tokens": 200_000,
+            "output_tokens": 100_000,
+        }
+        self.write_records(
+            {
+                "record_type": "run",
+                "run_id": "run-shared-1",
+                "command": "run",
+                "status": "success",
+                "parent_session_id": "parent-shared",
+                "started_at": "2026-08-12T10:00:00Z",
+                "completed_at": "2026-08-12T10:10:00Z",
+                "usage": usage,
+            },
+            {
+                "record_type": "run",
+                "run_id": "run-shared-2",
+                "command": "resume",
+                "status": "success",
+                "parent_session_id": "parent-shared",
+                "started_at": "2026-08-12T10:05:00Z",
+                "completed_at": "2026-08-12T10:15:00Z",
+                "usage": usage,
+            },
+        )
+        self.write_session(
+            "parent-shared",
+            (
+                "2026-08-12T09:59:00Z",
+                {"input_tokens": 100, "cached_input_tokens": 10, "output_tokens": 20},
+            ),
+            (
+                "2026-08-12T10:16:00Z",
+                {
+                    "input_tokens": 1_000_100,
+                    "cached_input_tokens": 100_010,
+                    "output_tokens": 100_020,
+                },
+            ),
+        )
+
+        summary = ANALYZER.summarize(
+            self.path,
+            rate_card_path=self.rate_card,
+            codex_sessions_root=self.sessions_root,
+        )
+
+        join = summary["parent_session_join"]
+        cost = summary["cost"]
+        self.assertEqual(join["shared_parent_sessions"], 1)
+        self.assertEqual(join["duplicate_parent_references"], 1)
+        self.assertEqual(cost["worker_credits"], 14.2)
+        self.assertEqual(cost["commander_credits"], 188.75)
+        self.assertEqual(cost["total_credits"], 202.95)
+
+    def test_missing_parent_is_visible_and_total_is_marked_incomplete(self) -> None:
+        self.write_records(
+            {
+                "record_type": "run",
+                "run_id": "run-missing-parent",
+                "command": "run",
+                "status": "success",
+                "parent_session_id": "parent-missing",
+                "started_at": "2026-08-12T10:00:00Z",
+                "completed_at": "2026-08-12T10:10:00Z",
+                "usage": {
+                    "input_tokens": 1_000_000,
+                    "cached_input_tokens": 0,
+                    "output_tokens": 0,
+                },
+            }
+        )
+        self.sessions_root.mkdir(parents=True)
+
+        summary = ANALYZER.summarize(
+            self.path,
+            rate_card_path=self.rate_card,
+            codex_sessions_root=self.sessions_root,
+        )
+
+        join = summary["parent_session_join"]
+        cost = summary["cost"]
+        self.assertEqual(join["missing_parent_sessions"], 1)
+        self.assertEqual(join["unresolved_parent_sessions"], 1)
+        self.assertEqual(join["parent_session_coverage"], 0.0)
+        self.assertEqual(cost["commander_credits"], 0)
+        self.assertIsNone(cost["total_credits"])
+        self.assertFalse(cost["total_estimate_complete"])
+        self.assertEqual(
+            summary["quality"]["normalized_credit_scope"],
+            "incomplete_commander_window_coverage",
+        )
+        self.assertEqual(summary["quality"]["worker_credits_per_verified_run"], None)
+        self.assertIsNone(summary["quality"]["credits_per_verified_run"])
+
+    def test_ambiguous_parent_is_visible_and_not_costed(self) -> None:
+        self.write_records(
+            {
+                "record_type": "run",
+                "run_id": "run-ambiguous-parent",
+                "command": "run",
+                "status": "success",
+                "parent_session_id": "parent-ambiguous",
+                "started_at": "2026-08-12T10:00:00Z",
+                "completed_at": "2026-08-12T10:10:00Z",
+                "usage": {
+                    "input_tokens": 1_000_000,
+                    "cached_input_tokens": 0,
+                    "output_tokens": 0,
+                },
+            }
+        )
+        usage = {
+            "input_tokens": 1_000_100,
+            "cached_input_tokens": 100_010,
+            "output_tokens": 100_020,
+        }
+        baseline = {
+            "input_tokens": 100,
+            "cached_input_tokens": 10,
+            "output_tokens": 20,
+        }
+        self.write_session(
+            "parent-ambiguous",
+            ("2026-08-12T09:59:00Z", baseline),
+            ("2026-08-12T10:11:00Z", usage),
+            filename="one.jsonl",
+        )
+        self.write_session(
+            "parent-ambiguous",
+            ("2026-08-12T09:59:00Z", baseline),
+            ("2026-08-12T10:11:00Z", usage),
+            filename="two.jsonl",
+        )
+
+        summary = ANALYZER.summarize(
+            self.path,
+            rate_card_path=self.rate_card,
+            codex_sessions_root=self.sessions_root,
+        )
+
+        join = summary["parent_session_join"]
+        self.assertEqual(join["ambiguous_parent_sessions"], 1)
+        self.assertEqual(join["unresolved_by_reason"], {"ambiguous_session_file": 1})
+        self.assertEqual(summary["cost"]["commander_credits"], 0)
+
+    def test_pre_and_post_unrelated_parent_usage_is_excluded(self) -> None:
+        self.write_records(
+            {
+                "record_type": "run",
+                "run_id": "run-window-boundary",
+                "command": "run",
+                "status": "success",
+                "parent_session_id": "parent-boundary",
+                "started_at": "2026-08-12T10:00:00Z",
+                "completed_at": "2026-08-12T10:10:00Z",
+                "usage": {
+                    "input_tokens": 1_000_000,
+                    "cached_input_tokens": 200_000,
+                    "output_tokens": 100_000,
+                },
+            }
+        )
+        self.write_session(
+            "parent-boundary",
+            (
+                "2026-08-12T08:00:00Z",
+                {"input_tokens": 10, "cached_input_tokens": 1, "output_tokens": 2},
+            ),
+            (
+                "2026-08-12T09:59:00Z",
+                {"input_tokens": 100, "cached_input_tokens": 10, "output_tokens": 20},
+            ),
+            (
+                "2026-08-12T10:11:00Z",
+                {
+                    "input_tokens": 1_000_100,
+                    "cached_input_tokens": 100_010,
+                    "output_tokens": 100_020,
+                },
+            ),
+            (
+                "2026-08-12T10:20:00Z",
+                {
+                    "input_tokens": 9_000_000,
+                    "cached_input_tokens": 900_000,
+                    "output_tokens": 900_000,
+                },
+            ),
+        )
+
+        summary = ANALYZER.summarize(
+            self.path,
+            rate_card_path=self.rate_card,
+            codex_sessions_root=self.sessions_root,
+        )
+
+        self.assertEqual(summary["cost"]["commander_window_credits"], 188.75)
+        self.assertEqual(
+            summary["parent_session_join"]["commander_window_token_totals"]["input_tokens"],
+            1_000_000,
+        )
+
+    def test_missing_baseline_makes_parent_window_unresolved(self) -> None:
+        self.write_records(
+            {
+                "record_type": "run",
+                "run_id": "run-no-baseline",
+                "command": "run",
+                "status": "success",
+                "parent_session_id": "parent-no-baseline",
+                "started_at": "2026-08-12T10:00:00Z",
+                "completed_at": "2026-08-12T10:10:00Z",
+                "usage": {
+                    "input_tokens": 10,
+                    "cached_input_tokens": 1,
+                    "output_tokens": 2,
+                },
+            }
+        )
+        self.write_session(
+            "parent-no-baseline",
+            (
+                "2026-08-12T10:01:00Z",
+                {"input_tokens": 100, "cached_input_tokens": 10, "output_tokens": 20},
+            ),
+            (
+                "2026-08-12T10:11:00Z",
+                {"input_tokens": 200, "cached_input_tokens": 20, "output_tokens": 30},
+            ),
+        )
+
+        summary = ANALYZER.summarize(
+            self.path,
+            rate_card_path=self.rate_card,
+            codex_sessions_root=self.sessions_root,
+        )
+
+        join = summary["parent_session_join"]
+        self.assertEqual(join["unresolved_by_reason"]["missing_baseline"], 1)
+        self.assertEqual(join["parent_window_coverage"], 0.0)
+        self.assertIsNone(summary["cost"]["total_credits"])
+
+    def test_missing_endpoint_makes_parent_window_unresolved(self) -> None:
+        self.write_records(
+            {
+                "record_type": "run",
+                "run_id": "run-no-endpoint",
+                "command": "run",
+                "status": "success",
+                "parent_session_id": "parent-no-endpoint",
+                "started_at": "2026-08-12T10:00:00Z",
+                "completed_at": "2026-08-12T10:10:00Z",
+                "usage": {
+                    "input_tokens": 10,
+                    "cached_input_tokens": 1,
+                    "output_tokens": 2,
+                },
+            }
+        )
+        self.write_session(
+            "parent-no-endpoint",
+            (
+                "2026-08-12T09:59:00Z",
+                {"input_tokens": 100, "cached_input_tokens": 10, "output_tokens": 20},
+            ),
+        )
+
+        summary = ANALYZER.summarize(
+            self.path,
+            rate_card_path=self.rate_card,
+            codex_sessions_root=self.sessions_root,
+        )
+
+        join = summary["parent_session_join"]
+        self.assertEqual(join["unresolved_by_reason"]["missing_endpoint"], 1)
+        self.assertEqual(join["parent_window_coverage"], 0.0)
+        self.assertIsNone(summary["cost"]["total_credits"])
+
+    def test_counter_decrease_or_reset_makes_parent_window_unresolved(self) -> None:
+        self.write_records(
+            {
+                "record_type": "run",
+                "run_id": "run-counter-reset",
+                "command": "run",
+                "status": "success",
+                "parent_session_id": "parent-counter-reset",
+                "started_at": "2026-08-12T10:00:00Z",
+                "completed_at": "2026-08-12T10:10:00Z",
+                "usage": {
+                    "input_tokens": 10,
+                    "cached_input_tokens": 1,
+                    "output_tokens": 2,
+                },
+            }
+        )
+        self.write_session(
+            "parent-counter-reset",
+            (
+                "2026-08-12T09:59:00Z",
+                {"input_tokens": 100, "cached_input_tokens": 10, "output_tokens": 20},
+            ),
+            (
+                "2026-08-12T10:05:00Z",
+                {"input_tokens": 90, "cached_input_tokens": 9, "output_tokens": 19},
+            ),
+            (
+                "2026-08-12T10:11:00Z",
+                {"input_tokens": 120, "cached_input_tokens": 12, "output_tokens": 24},
+            ),
+        )
+
+        summary = ANALYZER.summarize(
+            self.path,
+            rate_card_path=self.rate_card,
+            codex_sessions_root=self.sessions_root,
+        )
+
+        join = summary["parent_session_join"]
+        self.assertEqual(join["unresolved_by_reason"]["counter_decrease_or_reset"], 1)
+        self.assertEqual(summary["cost"]["commander_window_credits"], 0)
+        self.assertIsNone(summary["cost"]["total_credits"])
+
+    def test_partial_parent_windows_expose_partial_components_but_no_total_scope_metrics(self) -> None:
+        run_usage = {
+            "input_tokens": 1_000_000,
+            "cached_input_tokens": 200_000,
+            "output_tokens": 100_000,
+        }
+        self.write_records(
+            {
+                "record_type": "run",
+                "run_id": "run-partial-resolved",
+                "command": "run",
+                "status": "success",
+                "parent_session_id": "parent-resolved",
+                "started_at": "2026-08-12T10:00:00Z",
+                "completed_at": "2026-08-12T10:10:00Z",
+                "usage": run_usage,
+            },
+            {
+                "record_type": "run",
+                "run_id": "run-partial-missing",
+                "command": "run",
+                "status": "success",
+                "parent_session_id": "parent-missing-partial",
+                "started_at": "2026-08-12T11:00:00Z",
+                "completed_at": "2026-08-12T11:10:00Z",
+                "usage": run_usage,
+            },
+            {
+                "record_type": "evaluation",
+                "run_id": "run-partial-resolved",
+                "outcome": "verified",
+                "checks_passed": 1,
+                "checks_failed": 0,
+            },
+        )
+        self.write_session(
+            "parent-resolved",
+            (
+                "2026-08-12T09:59:00Z",
+                {"input_tokens": 100, "cached_input_tokens": 10, "output_tokens": 20},
+            ),
+            (
+                "2026-08-12T10:11:00Z",
+                {
+                    "input_tokens": 1_000_100,
+                    "cached_input_tokens": 100_010,
+                    "output_tokens": 100_020,
+                },
+            ),
+        )
+
+        summary = ANALYZER.summarize(
+            self.path,
+            rate_card_path=self.rate_card,
+            codex_sessions_root=self.sessions_root,
+        )
+
+        self.assertEqual(summary["cost"]["commander_window_credits"], 188.75)
+        self.assertIsNone(summary["cost"]["total_credits"])
+        self.assertIsNone(summary["quality"]["credits_per_verified_run"])
+        self.assertEqual(
+            summary["quality"]["worker_credits_per_verified_run"],
+            14.2,
+        )
+        self.assertEqual(summary["parent_session_join"]["parent_window_coverage"], 0.5)
+
+    def test_both_worker_and_commander_coverage_are_named_in_normalized_scope(self) -> None:
+        self.write_records(
+            {
+                "record_type": "run",
+                "run_id": "run-both-incomplete",
+                "command": "run",
+                "status": "failed",
+                "failure_code": "codex_exit",
+                "parent_session_id": "parent-both-incomplete",
+                "started_at": "2026-08-12T10:00:00Z",
+                "completed_at": "2026-08-12T10:10:00Z",
+            }
+        )
+        self.sessions_root.mkdir(parents=True)
+
+        summary = ANALYZER.summarize(
+            self.path,
+            rate_card_path=self.rate_card,
+            codex_sessions_root=self.sessions_root,
+        )
+
+        self.assertEqual(
+            summary["quality"]["normalized_credit_scope"],
+            "incomplete_worker_usage_and_commander_window_coverage",
+        )
+
+    def test_rate_card_rejects_malformed_or_negative_usage(self) -> None:
+        invalid_usages = (
+            {"input_tokens": "100", "cached_input_tokens": 0, "output_tokens": 1},
+            {"input_tokens": 100, "cached_input_tokens": -1, "output_tokens": 1},
+            {"input_tokens": 100, "cached_input_tokens": 101, "output_tokens": 1},
+        )
+        for index, usage in enumerate(invalid_usages):
+            with self.subTest(index=index):
+                self.write_records(
+                    {
+                        "record_type": "run",
+                        "run_id": f"run-invalid-{index}",
+                        "status": "success",
+                        "usage": usage,
+                    }
+                )
+                summary = ANALYZER.summarize(self.path, rate_card_path=self.rate_card)
+                self.assertEqual(summary["cost"]["worker_runs_costed"], 0)
+                self.assertEqual(summary["cost"]["worker_runs_unresolved"], 1)
+                self.assertFalse(summary["cost"]["worker_estimate_complete"])
+
+    def test_no_rate_card_preserves_non_estimating_backward_compatibility(self) -> None:
+        self.write_records(
+            {
+                "record_type": "run",
+                "run_id": "run-legacy",
+                "status": "success",
+                "usage": {
+                    "input_tokens": -10,
+                    "cached_input_tokens": "bad",
+                    "output_tokens": 4,
+                },
+            }
+        )
+
+        summary = ANALYZER.summarize(self.path)
+
+        self.assertNotIn("cost", summary)
+        self.assertNotIn("parent_session_join", summary)
+        self.assertEqual(summary["efficiency"]["token_totals"]["input_tokens"], 0)
+        json.dumps(summary, ensure_ascii=False, sort_keys=True)
+
+    def test_quality_normalized_metrics_use_available_credit_scope(self) -> None:
+        self.write_records(
+            {
+                "record_type": "run",
+                "run_id": "run-quality-1",
+                "command": "run",
+                "status": "success",
+                "usage": {
+                    "input_tokens": 1_000_000,
+                    "cached_input_tokens": 200_000,
+                    "output_tokens": 100_000,
+                },
+            },
+            {
+                "record_type": "run",
+                "run_id": "run-quality-2",
+                "command": "resume",
+                "status": "success",
+                "usage": {
+                    "input_tokens": 500_000,
+                    "cached_input_tokens": 0,
+                    "output_tokens": 0,
+                },
+            },
+            {
+                "record_type": "evaluation",
+                "run_id": "run-quality-1",
+                "outcome": "verified",
+                "checks_passed": 1,
+                "checks_failed": 0,
+            },
+            {
+                "record_type": "evaluation",
+                "run_id": "run-quality-2",
+                "outcome": "verified",
+                "checks_passed": 1,
+                "checks_failed": 0,
+            },
+        )
+
+        summary = ANALYZER.summarize(self.path, rate_card_path=self.rate_card)
+
+        quality = summary["quality"]
+        self.assertEqual(summary["cost"]["worker_credits"], 9.6)
+        self.assertEqual(quality["credits_per_verified_run"], 4.8)
+        self.assertEqual(quality["credits_per_first_pass_verified_run"], 9.6)
+        self.assertIsNone(quality["commander_credit_share"])
 
 
 if __name__ == "__main__":

--- a/skills/sol-luna-router/scripts/test_run_luna_worker.py
+++ b/skills/sol-luna-router/scripts/test_run_luna_worker.py
@@ -56,6 +56,9 @@ if mode == "malformed":
 if mode == "failure":
     print(json.dumps({"type": "error", "message": "simulated failure"}))
     raise SystemExit(7)
+if mode == "failure-with-usage":
+    print(json.dumps({"type": "turn.completed", "usage": {"input_tokens": 40, "cached_input_tokens": 10, "output_tokens": 8}}))
+    raise SystemExit(7)
 if mode == "capacity":
     print(json.dumps({"type": "error", "message": "usage limit reached"}))
     raise SystemExit(7)
@@ -67,6 +70,9 @@ if mode == "recovered":
     print(json.dumps({"type": "item.completed", "item": {"type": "error", "message": "Falling back to HTTPS transport"}}))
 if mode == "turn-failed":
     print(json.dumps({"type": "turn.failed", "error": {"message": "terminal failure"}}))
+if mode == "turn-failed-with-usage":
+    print(json.dumps({"type": "turn.failed", "usage": {"input_tokens": 30, "cached_input_tokens": 5, "output_tokens": 7}, "error": {"message": "terminal failure with usage"}}))
+    raise SystemExit(0)
 if mode == "missing-final-after-error":
     print(json.dumps({"type": "error", "message": "retry before empty completion"}))
     print(json.dumps({"type": "turn.completed", "usage": {"input_tokens": 10, "output_tokens": 0}}))
@@ -411,6 +417,24 @@ class RunnerTests(unittest.TestCase):
         self.assertEqual(result.returncode, 1)
         self.assertIn("usage limit reached", result.stderr)
         self.assertEqual(self.read_records()[0]["failure_code"], "capacity_exhausted")
+        self.assertNotIn("usage", self.read_records()[0])
+
+    def test_nonzero_exit_preserves_exact_usage_in_failure_telemetry(self) -> None:
+        result = self.invoke(
+            "run",
+            "--cwd",
+            str(self.repo),
+            "--prompt-file",
+            str(self.prompt),
+            mode="failure-with-usage",
+        )
+        self.assertEqual(result.returncode, 1)
+        record = self.read_records()[0]
+        self.assertEqual(record["failure_code"], "codex_exit")
+        self.assertEqual(
+            record["usage"],
+            {"input_tokens": 40, "cached_input_tokens": 10, "output_tokens": 8},
+        )
 
     def test_recovered_transport_errors_are_warnings_not_failures(self) -> None:
         result = self.invoke(
@@ -440,6 +464,35 @@ class RunnerTests(unittest.TestCase):
         )
         self.assertEqual(result.returncode, 1)
         self.assertIn("terminal failure", result.stderr)
+        self.assertNotIn("usage", self.read_records()[0])
+
+    def test_turn_failed_preserves_exact_usage_and_absent_usage_is_not_zero(self) -> None:
+        result = self.invoke(
+            "run",
+            "--cwd",
+            str(self.repo),
+            "--prompt-file",
+            str(self.prompt),
+            mode="turn-failed-with-usage",
+        )
+        self.assertEqual(result.returncode, 1)
+        record = self.read_records()[0]
+        self.assertEqual(record["failure_code"], "turn_failed")
+        self.assertEqual(
+            record["usage"],
+            {"input_tokens": 30, "cached_input_tokens": 5, "output_tokens": 7},
+        )
+
+        absent_result = self.invoke(
+            "run",
+            "--cwd",
+            str(self.repo),
+            "--prompt-file",
+            str(self.prompt),
+            mode="failure",
+        )
+        self.assertEqual(absent_result.returncode, 1)
+        self.assertNotIn("usage", self.read_records()[-1])
 
     def test_recovered_error_without_turn_completed_fails_closed(self) -> None:
         result = self.invoke(


### PR DESCRIPTION
## Summary

- add an opt-in, versioned historical credit rate card for Sol and Luna
- estimate Luna Max cost for every run with exact usage, including failed runs
- optionally join parent Sol session token snapshots using merged run-window deltas
- report worker and commander coverage, partial-cost boundaries, and cost per verified outcome
- preserve exact failure usage in future telemetry when Codex emits it

## Evidence and privacy

- default analysis remains token-only and does not read parent sessions
- rate-card use and parent-session joins are both explicit opt-ins
- joins read only session IDs, event timestamps/types, and cumulative token usage
- prompt and response text are never copied into the report or ledger
- incomplete Worker or Commander coverage produces `total_credits: null`
- the bundled 2026-08-05 rate card is labeled historical and not current pricing

## Validation

- `python3 skills/sol-luna-router/scripts/test_analyze_run_log.py` — 19 passed
- `python3 skills/sol-luna-router/scripts/test_run_luna_worker.py` — 22 passed
- Python compilation — passed
- `python3 scripts/validate_skills.py --check` — 0 errors, one pre-existing Threads length warning
- `python3 scripts/audit_skill_quality.py sol-luna-router` — clean
- `git diff --check` — clean

## Luna Max benchmark

A fresh replay used the same baseline tree and four hidden tests as the historical transport-warning benchmark:

- Luna Max worker: 10/10 focused tests, 4/4 hidden tests, compile and diff checks passed
- scope violations: 0
- Luna Max historical estimate: 0.865120 credits
- isolated Sol verification estimate: 1.847600 credits
- measured two-stage estimate: 2.712720 credits

The two-stage number excludes root-session preflight and dispatch, so it is deliberately not presented as complete routed-task cost. Two nested-CLI transport failures and one invalid read-only verification attempt were retained separately and excluded from the valid result.
