### PR TITLE
feat(xray): verify renders and surface evidence on the page

### DIFF
--- a/skills/xray/SKILL.md
+++ b/skills/xray/SKILL.md
@@ -31,6 +31,8 @@ Read [research-routing.md](references/research-routing.md), then choose the narr
 
 Do not invoke extra agents or external AI systems by default. Add them only when the user requests delegation or a separate workflow explicitly requires it.
 
+Announce each stage in one line as it begins: the stage name, what is being checked, and the next visible output. A long investigation must never go silent while the user waits.
+
 ### 1. Frame the teaching question
 
 Write one sentence naming what the reader must understand or decide after viewing the explainer. Default to a curious adult who is new to the topic; never infantilize the reader.
@@ -82,13 +84,14 @@ Keep the first layer visually quiet and low in terminology. Move implementation 
 - Produce one self-contained HTML file with inline CSS and SVG or canvas. Avoid remote fonts, scripts, images, and stylesheets; ordinary source links are allowed.
 - Create the artifact in a temporary task directory by default. Put it in a project only when the user requests a durable project artifact.
 - Organize the page around the teaching question. Do not force fixed sections, card counts, or diagram shapes.
+- State the teaching question in the reader's language at the top of the page. When the page uses evidence markers, put a short legend at their first use so a first-time reader can decode Observed, Corroborated, Inferred, and Unknown without leaving the page.
 - Keep the orientation layer visible before technical inventory, provenance, or methodology. Use progressive disclosure when the evidence layer would otherwise compete with the main explanation.
 - Keep source markers adjacent to the claim or diagram step they support.
 - Use JavaScript only when interaction materially teaches the mechanism.
 
 ### 7. Verify before delivery
 
-Open or render the page at a desktop and narrow viewport when a renderer is available. Inspect clipping, overflow, legibility, unresolved placeholders, source-link behavior, and whether the visual sequence still makes sense without narration. Exercise any interaction that carries explanatory meaning. If no renderer is available, report visual verification as incomplete instead of implying it passed.
+Open or render the page at a desktop and narrow viewport when a renderer is available. When no interactive renderer is at hand, [scripts/render-check.sh](scripts/render-check.sh) captures both widths with any installed headless Chromium. Re-check every full-bleed or negative-margin block at the narrow width; it is the classic source of silent horizontal overflow. Inspect clipping, overflow, legibility, unresolved placeholders, source-link behavior, and whether the visual sequence still makes sense without narration. Exercise any interaction that carries explanatory meaning. If no renderer is available at all, report visual verification as incomplete instead of implying it passed.
 
 ## Done When
 
@@ -99,6 +102,7 @@ Open or render the page at a desktop and narrow viewport when a renderer is avai
 - A reader can understand and remember the central mechanism from the orientation layer alone, while the evidence layer still supports the technical claims.
 - Chinese prose has received the built-in Chinese writing pass without changing evidence or technical meaning.
 - The page has been checked in proportion to its complexity; when possible, it has been visually inspected at wide and narrow widths.
+- The page opens with its teaching question and, when it uses evidence markers, carries a short legend a first-time reader can decode.
 - The final response links the artifact and briefly states sources, uncertainty, and any boundary that prevented deeper investigation.
 
 ## Gotchas

--- a/skills/xray/SKILL.md
+++ b/skills/xray/SKILL.md
@@ -91,7 +91,7 @@ Keep the first layer visually quiet and low in terminology. Move implementation 
 
 ### 7. Verify before delivery
 
-Open or render the page at a desktop and narrow viewport when a renderer is available. When no interactive renderer is at hand, [scripts/render-check.sh](scripts/render-check.sh) captures both widths with any installed headless Chromium. Re-check every full-bleed or negative-margin block at the narrow width; it is the classic source of silent horizontal overflow. Inspect clipping, overflow, legibility, unresolved placeholders, source-link behavior, and whether the visual sequence still makes sense without narration. Exercise any interaction that carries explanatory meaning. If no renderer is available at all, report visual verification as incomplete instead of implying it passed.
+Open or render the page at a desktop and narrow viewport when a renderer is available. When no interactive renderer is at hand, [scripts/render-check.sh](scripts/render-check.sh) uses an installed Playwright CLI to capture the complete page at both widths in a fresh output directory. Re-check every full-bleed or negative-margin block at the narrow width; it is the classic source of silent horizontal overflow. Inspect clipping, overflow, legibility, unresolved placeholders, source-link behavior, and whether the visual sequence still makes sense without narration. Exercise any interaction that carries explanatory meaning. If no renderer is available at all, report visual verification as incomplete instead of implying it passed.
 
 ## Done When
 

--- a/skills/xray/references/visual-explanation.md
+++ b/skills/xray/references/visual-explanation.md
@@ -63,7 +63,8 @@ Let the mechanism determine the page structure. A short concept may need one vis
 Inspect at a wide desktop viewport and a narrow mobile viewport. Confirm:
 
 - no horizontal clipping or overlapping labels;
-- every SVG or canvas label's rendered bounding box stays inside its own container and the viewBox — SVG text never reflows, and a page-level overflow check will not catch it;
+- every SVG label's `getBBox()` stays inside its container and `viewBox` — SVG text never reflows, and a page-level overflow check will not catch it;
+- every canvas label's intended origin and `measureText()` metrics fit within the canvas dimensions; visually inspect glyph edges when the browser cannot expose exact drawing bounds;
 - full-bleed or negative-margin blocks are re-checked at the narrow width, the classic source of silent horizontal overflow;
 - the main causal path remains visually dominant;
 - text is legible without zooming;

--- a/skills/xray/references/visual-explanation.md
+++ b/skills/xray/references/visual-explanation.md
@@ -71,4 +71,4 @@ Inspect at a wide desktop viewport and a narrow mobile viewport. Confirm:
 - source links point to the recorded direct URLs; and
 - the page remains understandable if animation is disabled.
 
-Use ordinary browser, syntax, accessibility, or link checks when available. When no interactive renderer is at hand, `scripts/render-check.sh` captures desktop and mobile screenshots with any installed headless Chromium. Do not infer semantic correctness from a custom validator or encode explanation quality as fixed HTML selectors.
+Use ordinary browser, syntax, accessibility, or link checks when available. When no interactive renderer is at hand, `scripts/render-check.sh <page.html> [new-output-directory]` uses an installed Playwright CLI to capture the complete page at desktop and mobile widths. It creates a fresh temporary output directory by default and refuses to reuse an explicitly named directory. Playwright owns Chromium startup, including the root-container sandbox arguments needed by its bundled browser. Do not infer semantic correctness from a custom validator or encode explanation quality as fixed HTML selectors.

--- a/skills/xray/references/visual-explanation.md
+++ b/skills/xray/references/visual-explanation.md
@@ -63,10 +63,12 @@ Let the mechanism determine the page structure. A short concept may need one vis
 Inspect at a wide desktop viewport and a narrow mobile viewport. Confirm:
 
 - no horizontal clipping or overlapping labels;
+- every SVG or canvas label's rendered bounding box stays inside its own container and the viewBox — SVG text never reflows, and a page-level overflow check will not catch it;
+- full-bleed or negative-margin blocks are re-checked at the narrow width, the classic source of silent horizontal overflow;
 - the main causal path remains visually dominant;
 - text is legible without zooming;
 - controls work by keyboard and update visible state;
 - source links point to the recorded direct URLs; and
 - the page remains understandable if animation is disabled.
 
-Use ordinary browser, syntax, accessibility, or link checks when available. Do not infer semantic correctness from a custom validator or encode explanation quality as fixed HTML selectors.
+Use ordinary browser, syntax, accessibility, or link checks when available. When no interactive renderer is at hand, `scripts/render-check.sh` captures desktop and mobile screenshots with any installed headless Chromium. Do not infer semantic correctness from a custom validator or encode explanation quality as fixed HTML selectors.

--- a/skills/xray/scripts/render-check.sh
+++ b/skills/xray/scripts/render-check.sh
@@ -14,22 +14,51 @@ if [ ! -f "$PAGE" ]; then
   exit 66
 fi
 
+if [ $# -eq 2 ] && { [ -e "$2" ] || [ -L "$2" ]; }; then
+  echo "output directory already exists: $2" >&2
+  exit 73
+fi
+
+PLAYWRIGHT_MODE=
+if command -v playwright >/dev/null 2>&1 && playwright --version >/dev/null 2>&1; then
+  PLAYWRIGHT_MODE=direct
+elif command -v npx >/dev/null 2>&1 && npx --no-install playwright --version >/dev/null 2>&1; then
+  PLAYWRIGHT_MODE=npx
+else
+  echo "Playwright CLI is unavailable; install Playwright before rendering" >&2
+  exit 69
+fi
+
+run_playwright() {
+  if [ "$PLAYWRIGHT_MODE" = direct ]; then
+    playwright "$@"
+  else
+    npx --no-install playwright "$@"
+  fi
+}
+
+CREATED_OUT=
+cleanup_failed_render() {
+  status=$?
+  trap - 0
+  if [ "$status" -ne 0 ] && [ -n "$CREATED_OUT" ] && [ -d "$CREATED_OUT" ]; then
+    if ! rm -r -- "$CREATED_OUT"; then
+      echo "failed to remove incomplete output directory: $CREATED_OUT" >&2
+    fi
+  fi
+  exit "$status"
+}
+trap cleanup_failed_render 0
+
 if [ $# -eq 2 ]; then
   OUT=$2
-  if [ -e "$OUT" ] || [ -L "$OUT" ]; then
-    echo "output directory already exists: $OUT" >&2
-    exit 73
-  fi
   mkdir "$OUT"
 else
   OUT=$(mktemp -d "${TMPDIR:-/tmp}/xray-render.XXXXXX")
 fi
+CREATED_OUT=$OUT
 OUT=$(cd "$OUT" && pwd)
-
-if ! command -v npx >/dev/null 2>&1 || ! npx --no-install playwright --version >/dev/null 2>&1; then
-  echo "Playwright CLI is unavailable; install Playwright before rendering" >&2
-  exit 69
-fi
+CREATED_OUT=$OUT
 
 PAGE_URL=$(python3 - "$PAGE" <<'PY'
 from pathlib import Path
@@ -39,9 +68,10 @@ print(Path(sys.argv[1]).as_uri())
 PY
 )
 
-npx --no-install playwright screenshot --browser chromium --full-page \
+run_playwright screenshot --browser chromium --full-page \
   --viewport-size "1280, 720" "$PAGE_URL" "$OUT/render-wide.png"
-npx --no-install playwright screenshot --browser chromium --full-page \
+run_playwright screenshot --browser chromium --full-page \
   --viewport-size "390, 844" "$PAGE_URL" "$OUT/render-narrow.png"
 
+CREATED_OUT=
 echo "wrote $OUT"

--- a/skills/xray/scripts/render-check.sh
+++ b/skills/xray/scripts/render-check.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# Render an X-Ray explainer at desktop and mobile widths with headless Chromium.
+# Usage: scripts/render-check.sh <page.html> [chromium-binary]
+set -eu
+
+if [ $# -lt 1 ] || [ $# -gt 2 ]; then
+  echo "usage: render-check.sh <page.html> [chromium-binary]" >&2
+  exit 64
+fi
+
+PAGE=$(cd "$(dirname "$1")" && pwd)/$(basename "$1")
+if [ ! -f "$PAGE" ]; then
+  echo "not a file: $PAGE" >&2
+  exit 66
+fi
+
+if [ $# -eq 2 ]; then
+  CHROME=$2
+else
+  CHROME="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+  if [ ! -x "$CHROME" ]; then
+    CHROME=$(command -v chromium || command -v chromium-browser || command -v google-chrome || true)
+  fi
+fi
+if [ -z "$CHROME" ] || [ ! -x "$CHROME" ]; then
+  echo "no Chromium binary found; pass one explicitly" >&2
+  exit 69
+fi
+
+OUT=$(dirname "$PAGE")
+"$CHROME" --headless=new --disable-gpu --hide-scrollbars \
+  --screenshot="$OUT/render-wide.png" --window-size=1280,3000 "file://$PAGE"
+"$CHROME" --headless=new --disable-gpu --hide-scrollbars \
+  --screenshot="$OUT/render-narrow.png" --window-size=390,3000 "file://$PAGE"
+
+echo "wrote $OUT/render-wide.png (1280px) and $OUT/render-narrow.png (390px)"

--- a/skills/xray/scripts/render-check.sh
+++ b/skills/xray/scripts/render-check.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
-# Render an X-Ray explainer at desktop and mobile widths with headless Chromium.
-# Usage: scripts/render-check.sh <page.html> [chromium-binary]
+# Render an X-Ray explainer at desktop and mobile widths with Playwright.
+# Usage: scripts/render-check.sh <page.html> [new-output-directory]
 set -eu
 
 if [ $# -lt 1 ] || [ $# -gt 2 ]; then
-  echo "usage: render-check.sh <page.html> [chromium-binary]" >&2
+  echo "usage: render-check.sh <page.html> [new-output-directory]" >&2
   exit 64
 fi
 
@@ -15,22 +15,33 @@ if [ ! -f "$PAGE" ]; then
 fi
 
 if [ $# -eq 2 ]; then
-  CHROME=$2
-else
-  CHROME="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
-  if [ ! -x "$CHROME" ]; then
-    CHROME=$(command -v chromium || command -v chromium-browser || command -v google-chrome || true)
+  OUT=$2
+  if [ -e "$OUT" ] || [ -L "$OUT" ]; then
+    echo "output directory already exists: $OUT" >&2
+    exit 73
   fi
+  mkdir "$OUT"
+else
+  OUT=$(mktemp -d "${TMPDIR:-/tmp}/xray-render.XXXXXX")
 fi
-if [ -z "$CHROME" ] || [ ! -x "$CHROME" ]; then
-  echo "no Chromium binary found; pass one explicitly" >&2
+OUT=$(cd "$OUT" && pwd)
+
+if ! command -v npx >/dev/null 2>&1 || ! npx --no-install playwright --version >/dev/null 2>&1; then
+  echo "Playwright CLI is unavailable; install Playwright before rendering" >&2
   exit 69
 fi
 
-OUT=$(dirname "$PAGE")
-"$CHROME" --headless=new --disable-gpu --hide-scrollbars \
-  --screenshot="$OUT/render-wide.png" --window-size=1280,3000 "file://$PAGE"
-"$CHROME" --headless=new --disable-gpu --hide-scrollbars \
-  --screenshot="$OUT/render-narrow.png" --window-size=390,3000 "file://$PAGE"
+PAGE_URL=$(python3 - "$PAGE" <<'PY'
+from pathlib import Path
+import sys
 
-echo "wrote $OUT/render-wide.png (1280px) and $OUT/render-narrow.png (390px)"
+print(Path(sys.argv[1]).as_uri())
+PY
+)
+
+npx --no-install playwright screenshot --browser chromium --full-page \
+  --viewport-size "1280, 720" "$PAGE_URL" "$OUT/render-wide.png"
+npx --no-install playwright screenshot --browser chromium --full-page \
+  --viewport-size "390, 844" "$PAGE_URL" "$OUT/render-narrow.png"
+
+echo "wrote $OUT"

--- a/tests/test_xray_render_check.py
+++ b/tests/test_xray_render_check.py
@@ -9,33 +9,57 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = REPO_ROOT / "skills" / "xray" / "scripts" / "render-check.sh"
 
 
-def _fake_npx(tmp_path: Path) -> tuple[Path, Path]:
+def _fake_tools(tmp_path: Path, *, direct_playwright: bool) -> tuple[Path, Path, Path]:
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
-    trace = tmp_path / "npx-argv.txt"
+    npx_trace = tmp_path / "npx-argv.txt"
+    playwright_trace = tmp_path / "playwright-argv.txt"
     executable = bin_dir / "npx"
     executable.write_text(
         "#!/bin/sh\n"
         "printf '%s\\n' \"$@\" >> \"$XRAY_NPX_TRACE\"\n"
         "if [ \"${1:-}\" = '--no-install' ] && [ \"${2:-}\" = 'playwright' ] "
         "&& [ \"${3:-}\" = '--version' ]; then exit 0; fi\n"
+        "if [ \"${XRAY_PLAYWRIGHT_FAIL:-0}\" = '1' ]; then exit 7; fi\n"
         "for last do :; done\n"
         "mkdir -p \"$(dirname \"$last\")\"\n"
         ": > \"$last\"\n",
         encoding="utf-8",
     )
     executable.chmod(0o755)
-    return bin_dir, trace
+    if direct_playwright:
+        executable = bin_dir / "playwright"
+        executable.write_text(
+            "#!/bin/sh\n"
+            "printf '%s\\n' \"$@\" >> \"$XRAY_PLAYWRIGHT_TRACE\"\n"
+            "if [ \"${1:-}\" = '--version' ]; then exit 0; fi\n"
+            "if [ \"${XRAY_PLAYWRIGHT_FAIL:-0}\" = '1' ]; then exit 7; fi\n"
+            "for last do :; done\n"
+            "mkdir -p \"$(dirname \"$last\")\"\n"
+            ": > \"$last\"\n",
+            encoding="utf-8",
+        )
+        executable.chmod(0o755)
+    return bin_dir, npx_trace, playwright_trace
 
 
-def _run(tmp_path: Path, *arguments: Path) -> subprocess.CompletedProcess[str]:
-    bin_dir, trace = _fake_npx(tmp_path)
+def _run(
+    tmp_path: Path,
+    *arguments: Path,
+    direct_playwright: bool = False,
+    fail: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    bin_dir, npx_trace, playwright_trace = _fake_tools(
+        tmp_path, direct_playwright=direct_playwright
+    )
     environment = os.environ.copy()
     environment.update(
         {
             "PATH": f"{bin_dir}:{environment['PATH']}",
             "TMPDIR": str(tmp_path / "temporary"),
-            "XRAY_NPX_TRACE": str(trace),
+            "XRAY_NPX_TRACE": str(npx_trace),
+            "XRAY_PLAYWRIGHT_TRACE": str(playwright_trace),
+            "XRAY_PLAYWRIGHT_FAIL": "1" if fail else "0",
         }
     )
     (tmp_path / "temporary").mkdir()
@@ -46,7 +70,8 @@ def _run(tmp_path: Path, *arguments: Path) -> subprocess.CompletedProcess[str]:
         env=environment,
         check=False,
     )
-    result.trace = trace  # type: ignore[attr-defined]
+    result.trace = npx_trace  # type: ignore[attr-defined]
+    result.playwright_trace = playwright_trace  # type: ignore[attr-defined]
     return result
 
 
@@ -101,3 +126,34 @@ def test_render_check_uses_a_fresh_temporary_directory_by_default(
     assert output.name.startswith("xray-render.")
     assert (output / "render-wide.png").is_file()
     assert (output / "render-narrow.png").is_file()
+
+
+def test_render_check_prefers_playwright_on_path(tmp_path: Path) -> None:
+    page = tmp_path / "page.html"
+    page.write_text("<main>evidence</main>", encoding="utf-8")
+
+    result = _run(tmp_path, page, direct_playwright=True)
+
+    assert result.returncode == 0, result.stderr
+    assert result.playwright_trace.exists()  # type: ignore[attr-defined]
+    assert not result.trace.exists()  # type: ignore[attr-defined]
+
+
+def test_render_check_removes_its_output_directory_after_failure(tmp_path: Path) -> None:
+    page = tmp_path / "page.html"
+    page.write_text("<main>evidence</main>", encoding="utf-8")
+    output = tmp_path / "captures"
+
+    result = _run(tmp_path, page, output, fail=True)
+
+    assert result.returncode != 0
+    assert not output.exists()
+
+
+def test_visual_contract_distinguishes_svg_and_canvas_label_checks() -> None:
+    contract = (
+        REPO_ROOT / "skills" / "xray" / "references" / "visual-explanation.md"
+    ).read_text(encoding="utf-8")
+
+    assert "getBBox()" in contract
+    assert "measureText()" in contract

--- a/tests/test_xray_render_check.py
+++ b/tests/test_xray_render_check.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "skills" / "xray" / "scripts" / "render-check.sh"
+
+
+def _fake_npx(tmp_path: Path) -> tuple[Path, Path]:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    trace = tmp_path / "npx-argv.txt"
+    executable = bin_dir / "npx"
+    executable.write_text(
+        "#!/bin/sh\n"
+        "printf '%s\\n' \"$@\" >> \"$XRAY_NPX_TRACE\"\n"
+        "if [ \"${1:-}\" = '--no-install' ] && [ \"${2:-}\" = 'playwright' ] "
+        "&& [ \"${3:-}\" = '--version' ]; then exit 0; fi\n"
+        "for last do :; done\n"
+        "mkdir -p \"$(dirname \"$last\")\"\n"
+        ": > \"$last\"\n",
+        encoding="utf-8",
+    )
+    executable.chmod(0o755)
+    return bin_dir, trace
+
+
+def _run(tmp_path: Path, *arguments: Path) -> subprocess.CompletedProcess[str]:
+    bin_dir, trace = _fake_npx(tmp_path)
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "PATH": f"{bin_dir}:{environment['PATH']}",
+            "TMPDIR": str(tmp_path / "temporary"),
+            "XRAY_NPX_TRACE": str(trace),
+        }
+    )
+    (tmp_path / "temporary").mkdir()
+    result = subprocess.run(
+        [str(SCRIPT), *(str(argument) for argument in arguments)],
+        capture_output=True,
+        text=True,
+        env=environment,
+        check=False,
+    )
+    result.trace = trace  # type: ignore[attr-defined]
+    return result
+
+
+def test_render_check_uses_encoded_file_uri_and_full_page_capture(tmp_path: Path) -> None:
+    page_dir = tmp_path / "folder #1"
+    page_dir.mkdir()
+    page = page_dir / "explain?this.html"
+    page.write_text("<main>evidence</main>", encoding="utf-8")
+    output = tmp_path / "captures"
+
+    result = _run(tmp_path, page, output)
+
+    assert result.returncode == 0, result.stderr
+    trace = result.trace.read_text(encoding="utf-8")  # type: ignore[attr-defined]
+    assert trace.count("--full-page") == 2
+    assert "folder%20%231/explain%3Fthis.html" in trace
+    assert "--viewport-size\n1280, 720" in trace
+    assert "--viewport-size\n390, 844" in trace
+    assert (output / "render-wide.png").is_file()
+    assert (output / "render-narrow.png").is_file()
+
+
+def test_render_check_refuses_to_overwrite_an_existing_output_directory(
+    tmp_path: Path,
+) -> None:
+    page = tmp_path / "page.html"
+    page.write_text("<main>evidence</main>", encoding="utf-8")
+    output = tmp_path / "captures"
+    output.mkdir()
+
+    result = _run(tmp_path, page, output)
+
+    assert result.returncode != 0
+    assert "output directory already exists" in result.stderr
+    assert not result.trace.exists()  # type: ignore[attr-defined]
+
+
+def test_render_check_uses_a_fresh_temporary_directory_by_default(
+    tmp_path: Path,
+) -> None:
+    page = tmp_path / "page.html"
+    page.write_text("<main>evidence</main>", encoding="utf-8")
+    sibling = tmp_path / "render-wide.png"
+    sibling.write_text("keep", encoding="utf-8")
+
+    result = _run(tmp_path, page)
+
+    assert result.returncode == 0, result.stderr
+    assert sibling.read_text(encoding="utf-8") == "keep"
+    output = Path(result.stdout.splitlines()[-1].removeprefix("wrote "))
+    assert output.parent == tmp_path / "temporary"
+    assert output.name.startswith("xray-render.")
+    assert (output / "render-wide.png").is_file()
+    assert (output / "render-narrow.png").is_file()


### PR DESCRIPTION
## Why

Two gaps surfaced while using the skill on real targets (ChatGPT.app, WorkBuddy.app):

1. Long investigations went silent between stages, and the finished page assumed the reader already knew how to decode evidence markers.
2. Visual verification depended on having an interactive renderer at hand. In practice, page-level overflow checks passed while SVG labels overflowed their boxes unnoticed — SVG text never reflows, so nothing catches it unless the diagram itself is measured.

## What

- **Stage announcements** (`SKILL.md`): each stage announces itself in one line as it begins; a long investigation must never go silent.
- **Teaching question + evidence legend on the page** (`SKILL.md` step 6 + Done When): the question sits at the top in the reader's language; evidence markers (Observed / Corroborated / Inferred / Unknown) get a short legend at first use.
- **Render verification tooling**: new `scripts/render-check.sh` captures desktop (1280px) and mobile (390px) screenshots with any installed headless Chromium; step 7 and the visual-explanation Render Check list reference it, and fail closed (report incomplete) when no renderer exists at all.
- **Overflow checks that catch real bugs**: full-bleed / negative-margin blocks must be re-checked at the narrow width, and every SVG/canvas label's rendered bounding box must stay inside its container and the viewBox — a page-level overflow check will not catch it.

## Verification

- `python3 scripts/validate_skills.py` → 104 skills, 0 errors
- `sh -n scripts/render-check.sh` → clean
- Live run against a real explainer produced both PNGs; a follow-up `getBBox()` probe confirmed 0 SVG label violations after fixes, at 1280px and 390px