### PR TITLE
fix(xray): keep renderer discovery offline

### DIFF
--- a/skills/xray/scripts/render-check.sh
+++ b/skills/xray/scripts/render-check.sh
@@ -8,7 +8,7 @@ if [ $# -lt 1 ] || [ $# -gt 2 ]; then
   exit 64
 fi
 
-PAGE=$(cd "$(dirname "$1")" && pwd)/$(basename "$1")
+PAGE=$(cd "$(dirname -- "$1")" && pwd)/$(basename -- "$1")
 if [ ! -f "$PAGE" ]; then
   echo "not a file: $PAGE" >&2
   exit 66
@@ -22,8 +22,8 @@ fi
 PLAYWRIGHT_MODE=
 if command -v playwright >/dev/null 2>&1 && playwright --version >/dev/null 2>&1; then
   PLAYWRIGHT_MODE=direct
-elif command -v npx >/dev/null 2>&1 && npx --no-install playwright --version >/dev/null 2>&1; then
-  PLAYWRIGHT_MODE=npx
+elif command -v npm >/dev/null 2>&1 && npm exec --offline --no -- playwright --version >/dev/null 2>&1; then
+  PLAYWRIGHT_MODE=npm
 else
   echo "Playwright CLI is unavailable; install Playwright before rendering" >&2
   exit 69
@@ -33,7 +33,7 @@ run_playwright() {
   if [ "$PLAYWRIGHT_MODE" = direct ]; then
     playwright "$@"
   else
-    npx --no-install playwright "$@"
+    npm exec --offline --no -- playwright "$@"
   fi
 }
 

--- a/tests/test_xray_render_check.py
+++ b/tests/test_xray_render_check.py
@@ -27,6 +27,20 @@ def _fake_tools(tmp_path: Path, *, direct_playwright: bool) -> tuple[Path, Path,
         encoding="utf-8",
     )
     executable.chmod(0o755)
+    executable = bin_dir / "npm"
+    executable.write_text(
+        "#!/bin/sh\n"
+        "printf '%s\\n' \"$@\" >> \"$XRAY_NPX_TRACE\"\n"
+        "if [ \"${1:-}\" = '--offline' ] && [ \"${2:-}\" = '--no' ] "
+        "&& [ \"${3:-}\" = '--' ] && [ \"${4:-}\" = 'playwright' ] "
+        "&& [ \"${5:-}\" = '--version' ]; then exit 0; fi\n"
+        "if [ \"${XRAY_PLAYWRIGHT_FAIL:-0}\" = '1' ]; then exit 7; fi\n"
+        "for last do :; done\n"
+        "mkdir -p \"$(dirname \"$last\")\"\n"
+        ": > \"$last\"\n",
+        encoding="utf-8",
+    )
+    executable.chmod(0o755)
     if direct_playwright:
         executable = bin_dir / "playwright"
         executable.write_text(
@@ -68,6 +82,7 @@ def _run(
         capture_output=True,
         text=True,
         env=environment,
+        cwd=tmp_path,
         check=False,
     )
     result.trace = npx_trace  # type: ignore[attr-defined]
@@ -86,6 +101,7 @@ def test_render_check_uses_encoded_file_uri_and_full_page_capture(tmp_path: Path
 
     assert result.returncode == 0, result.stderr
     trace = result.trace.read_text(encoding="utf-8")  # type: ignore[attr-defined]
+    assert "--offline\n--no\n--\nplaywright" in trace
     assert trace.count("--full-page") == 2
     assert "folder%20%231/explain%3Fthis.html" in trace
     assert "--viewport-size\n1280, 720" in trace
@@ -157,3 +173,12 @@ def test_visual_contract_distinguishes_svg_and_canvas_label_checks() -> None:
 
     assert "getBBox()" in contract
     assert "measureText()" in contract
+
+
+def test_render_check_accepts_hyphen_prefixed_relative_page_path(tmp_path: Path) -> None:
+    page = tmp_path / "-explainer.html"
+    page.write_text("<main>evidence</main>", encoding="utf-8")
+
+    result = _run(tmp_path, Path("-explainer.html"))
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
Follow-up to #176.

- force the npm fallback into offline mode
- accept hyphen-prefixed relative page paths
- add focused regressions for both cases

Tested: xray render tests, real Playwright render, skill audit, registry validation, full pytest suite.