### PR TITLE
test(codex): ignore reaped zombie entries

### DIFF
--- a/tests/test_codex_timeout.py
+++ b/tests/test_codex_timeout.py
@@ -15,9 +15,16 @@ ROOT = Path(__file__).resolve().parents[1]
 SUPERVISOR = ROOT / "skills" / "codex" / "scripts" / "run_with_timeout.py"
 
 
-def process_group_has_live_members(group_id: int) -> bool:
-    timeout_module = runpy.run_path(str(SUPERVISOR))
-    return timeout_module["process_group_has_live_members"](group_id)
+def process_is_live(process_id: int) -> bool:
+    result = subprocess.run(
+        ["ps", "-o", "stat=", "-p", str(process_id)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode not in {0, 1}:
+        raise AssertionError(f"cannot inspect process {process_id}: {result.stderr.strip()}")
+    return any(state and not state.startswith("Z") for state in result.stdout.split())
 
 
 def test_process_group_inspection_ignores_zombies(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -161,6 +168,7 @@ time.sleep(60)
 
 def test_supervisor_kills_descendant_after_group_leader_exits(tmp_path: Path) -> None:
     group_id_file = tmp_path / "group-id"
+    child_pid_file = tmp_path / "child-pid"
     helper = tmp_path / "leader.py"
     helper.write_text(
         """\
@@ -171,7 +179,7 @@ import subprocess
 import sys
 import time
 
-group_id_file = sys.argv[1]
+group_id_file, child_pid_file = sys.argv[1:]
 child_code = '''
 import signal
 import time
@@ -179,31 +187,44 @@ import time
 signal.signal(signal.SIGTERM, signal.SIG_IGN)
 time.sleep(60)
 '''
-subprocess.Popen(
+child = subprocess.Popen(
     [sys.executable, "-c", child_code],
     stdin=subprocess.DEVNULL,
     stdout=subprocess.DEVNULL,
     stderr=subprocess.DEVNULL,
 )
 pathlib.Path(group_id_file).write_text(str(os.getpgrp()), encoding="utf-8")
+target = pathlib.Path(child_pid_file)
+temporary = target.with_suffix(".tmp")
+temporary.write_text(str(child.pid), encoding="utf-8")
+temporary.replace(target)
 time.sleep(60)
 """,
         encoding="utf-8",
     )
 
     result = subprocess.run(
-        [sys.executable, str(SUPERVISOR), "0.3", sys.executable, str(helper), str(group_id_file)],
+        [
+            sys.executable,
+            str(SUPERVISOR),
+            "0.3",
+            sys.executable,
+            str(helper),
+            str(group_id_file),
+            str(child_pid_file),
+        ],
         capture_output=True,
         text=True,
         check=False,
     )
 
     group_id = int(group_id_file.read_text(encoding="utf-8"))
-    live_members = process_group_has_live_members(group_id)
-    if live_members:
+    child_pid = int(child_pid_file.read_text(encoding="utf-8"))
+    child_is_live = process_is_live(child_pid)
+    if child_is_live:
         os.killpg(group_id, signal.SIGKILL)
     assert result.returncode == 124
-    assert not live_members
+    assert not child_is_live
 
 
 def test_supervisor_keeps_deadline_after_leader_exits_normally(tmp_path: Path) -> None:
@@ -259,12 +280,13 @@ while not pathlib.Path(child_pid_file).exists():
         check=False,
     )
 
+    child_pid = int(child_pid_file.read_text(encoding="utf-8"))
     group_id = int(group_id_file.read_text(encoding="utf-8"))
-    live_members = process_group_has_live_members(group_id)
-    if live_members:
+    child_is_live = process_is_live(child_pid)
+    if child_is_live:
         os.killpg(group_id, signal.SIGKILL)
     assert result.returncode == 124
-    assert not live_members
+    assert not child_is_live
 
 
 @pytest.mark.parametrize(
@@ -305,8 +327,8 @@ time.sleep(60)
 
     supervisor.send_signal(termination_signal)
     return_code = supervisor.wait(timeout=10)
-    live_members = process_group_has_live_members(child_pid)
-    if live_members:
+    child_is_live = process_is_live(child_pid)
+    if child_is_live:
         os.killpg(child_pid, signal.SIGKILL)
     assert return_code == 128 + termination_signal
-    assert not live_members
+    assert not child_is_live

--- a/tests/test_codex_timeout.py
+++ b/tests/test_codex_timeout.py
@@ -15,6 +15,11 @@ ROOT = Path(__file__).resolve().parents[1]
 SUPERVISOR = ROOT / "skills" / "codex" / "scripts" / "run_with_timeout.py"
 
 
+def process_group_has_live_members(group_id: int) -> bool:
+    timeout_module = runpy.run_path(str(SUPERVISOR))
+    return timeout_module["process_group_has_live_members"](group_id)
+
+
 def test_process_group_inspection_ignores_zombies(monkeypatch: pytest.MonkeyPatch) -> None:
     timeout_module = runpy.run_path(str(SUPERVISOR))
     has_live_members = timeout_module["process_group_has_live_members"]
@@ -194,9 +199,11 @@ time.sleep(60)
     )
 
     group_id = int(group_id_file.read_text(encoding="utf-8"))
-    with pytest.raises(ProcessLookupError):
-        os.killpg(group_id, 0)
+    live_members = process_group_has_live_members(group_id)
+    if live_members:
+        os.killpg(group_id, signal.SIGKILL)
     assert result.returncode == 124
+    assert not live_members
 
 
 def test_supervisor_keeps_deadline_after_leader_exits_normally(tmp_path: Path) -> None:
@@ -252,17 +259,12 @@ while not pathlib.Path(child_pid_file).exists():
         check=False,
     )
 
-    child_pid = int(child_pid_file.read_text(encoding="utf-8"))
     group_id = int(group_id_file.read_text(encoding="utf-8"))
-    try:
-        os.kill(child_pid, 0)
-    except ProcessLookupError:
-        child_exists = False
-    else:
-        child_exists = True
+    live_members = process_group_has_live_members(group_id)
+    if live_members:
         os.killpg(group_id, signal.SIGKILL)
     assert result.returncode == 124
-    assert not child_exists
+    assert not live_members
 
 
 @pytest.mark.parametrize(
@@ -303,12 +305,8 @@ time.sleep(60)
 
     supervisor.send_signal(termination_signal)
     return_code = supervisor.wait(timeout=10)
-    try:
-        os.kill(child_pid, 0)
-    except ProcessLookupError:
-        child_exists = False
-    else:
-        child_exists = True
+    live_members = process_group_has_live_members(child_pid)
+    if live_members:
         os.killpg(child_pid, signal.SIGKILL)
     assert return_code == 128 + termination_signal
-    assert not child_exists
+    assert not live_members


### PR DESCRIPTION
## Summary
- use the timeout supervisor's non-zombie process-group probe in lifecycle tests
- keep cleanup for genuinely live descendants
- avoid container-specific failures when PID 1 retains zombie entries

## Verification
- `uv run --python 3.11 --with pyyaml python scripts/validate_skills.py --check`
- `python3 scripts/audit_skill_quality.py threads codex build-product-demo`
- `python3 -m py_compile skills/threads/scripts/*.py skills/codex/scripts/*.py skills/build-product-demo/scripts/*.py`
- `PYTHONDONTWRITEBYTECODE=1 uvx --python 3.13 --from pytest --with pyyaml pytest -q` (505 passed, 136 subtests)