### PR TITLE
feat(codex): add focused Spellbook UI plugin

### DIFF
--- a/docs/creating-plugins.md
+++ b/docs/creating-plugins.md
@@ -1,11 +1,14 @@
 # Creating Plugins Guide
 
-Spellbook plugin packaging currently targets Claude Code. Plugins in this
-repository use `.claude-plugin/plugin.json`; this repository does not define a
-Codex plugin manifest. For Codex, distribute skills through direct skill install
-with `install.sh --target codex` or a manual catalog install that preserves the
-source layout: copy or symlink directory skills as whole directories, and place
-file skills under `$HOME/.agents/skills/<skill-name>/SKILL.md`.
+Spellbook supports its existing Claude Code plugin packages and one focused
+Codex plugin pilot. Claude Code plugins use `.claude-plugin/plugin.json`; the
+Codex pilot at `plugins/spellbook-ui` uses `.codex-plugin/plugin.json` and
+packages only four UI workflow skills. Direct skill installation remains the
+default public Codex path.
+
+The Codex pilot is not a public marketplace release. See
+[`plugins/spellbook-ui/README.md`](../plugins/spellbook-ui/README.md) for local
+validation and temporary-marketplace installation.
 
 ## Claude Code Plugin Structure
 
@@ -61,13 +64,11 @@ unless the plugin runtime you target documents directory skill support.
 
 For the top-level Spellbook catalog installed by `install.sh`, see [Skill Format Policy](./skill-format-policy.md). New catalog skills should generally use the directory layout when they need progressive disclosure, templates, scripts, evals, or other companion files.
 
-Codex does not use a plugin package from this repository today. Codex skills are
-installed directly from the catalog source into `$HOME/.agents/skills`, either
-through `install.sh --target codex` or a manual catalog install. For directory
-skills, copy or symlink the whole `skills/<name>/` directory so companion
-`references/`, `scripts/`, `assets/`, and other support files stay available.
-For file skills, install `skills/<name>.SKILL.md` as
-`$HOME/.agents/skills/<name>/SKILL.md`.
+Codex users normally install skills directly from the catalog. The focused
+`spellbook-ui` pilot is the exception: it packages complete copies of four
+directory skills under its own `skills/` directory so companion references,
+scripts, templates, and evals remain available. It does not add apps, MCP
+servers, hooks, agents, or authentication.
 
 Plugin skill files use this frontmatter:
 
@@ -147,7 +148,7 @@ Agent behavior and instructions...
    /plugin install my-plugin
    ```
 
-For Codex users, direct installation into `$HOME/.agents/skills` is only a
-local raw-catalog workaround for testing or internal use. Do not present it as
-the Codex publishing path. Document Codex plugin publishing only after this
-repository adds a supported Codex plugin package and manifest.
+For Codex users, direct installation with the maintained `skills` CLI remains
+the public path. The `spellbook-ui` manifest is valid for a local plugin pilot,
+but it is not a publishing claim. Document a public Codex marketplace only
+after a real marketplace release has been verified.

--- a/plugins/spellbook-ui/.codex-plugin/plugin.json
+++ b/plugins/spellbook-ui/.codex-plugin/plugin.json
@@ -1,0 +1,27 @@
+{
+  "name": "spellbook-ui",
+  "version": "0.1.0",
+  "description": "A focused Spellbook UI workflow for designing and implementing product interfaces in Codex.",
+  "author": {
+    "name": "majiayu000",
+    "url": "https://github.com/majiayu000"
+  },
+  "homepage": "https://majiayu000.github.io/spellbook/skills.html",
+  "repository": "https://github.com/majiayu000/spellbook",
+  "license": "MIT",
+  "keywords": ["ui", "frontend", "design-system", "figma"],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Spellbook UI",
+    "shortDescription": "Design and implement polished product interfaces.",
+    "longDescription": "Four focused Spellbook skills for frontend design, app UI, design systems, and Figma-to-React handoff.",
+    "developerName": "Spellbook",
+    "category": "Productivity",
+    "capabilities": [],
+    "defaultPrompt": [
+      "Design a polished first screen for this product.",
+      "Turn this UI brief into an implementation-ready design system.",
+      "Plan a faithful Figma-to-React implementation."
+    ]
+  }
+}

--- a/plugins/spellbook-ui/README.md
+++ b/plugins/spellbook-ui/README.md
@@ -1,0 +1,65 @@
+# Spellbook UI for Codex
+
+This is a focused Codex plugin pilot containing exactly four Spellbook skills:
+
+- `frontend-design`
+- `app-ui-design`
+- `ui-design-system`
+- `figma-to-react`
+
+The files under `skills/` are packaged copies of the canonical catalog skills
+at the repository root. Each directory includes the companion references,
+scripts, templates, or evals used by that skill.
+
+## Validate locally
+
+From the Spellbook repository root, use the validator shipped with Codex's
+`plugin-creator` skill:
+
+```bash
+PLUGIN_CREATOR="${CODEX_HOME:-$HOME/.codex}/skills/.system/plugin-creator"
+python3 "$PLUGIN_CREATOR/scripts/validate_plugin.py" plugins/spellbook-ui
+```
+
+Then run the normal Spellbook checks:
+
+```bash
+python3 scripts/validate_skills.py --check
+PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -q
+```
+
+## Install for a local pilot
+
+Codex installs plugins from configured marketplace snapshots. This repository
+does not publish a Codex marketplace entry yet. To test without changing that
+distribution claim, create a temporary local marketplace with the supported
+plugin creator, replace its placeholder plugin with this validated source, and
+install from that local marketplace:
+
+```bash
+PLUGIN_CREATOR="${CODEX_HOME:-$HOME/.codex}/skills/.system/plugin-creator"
+SPELLBOOK_ROOT="$(pwd)"
+PILOT_ROOT="$(mktemp -d)"
+
+python3 "$PLUGIN_CREATOR/scripts/create_basic_plugin.py" spellbook-ui \
+  --path "$PILOT_ROOT/plugins" \
+  --marketplace-path "$PILOT_ROOT/marketplace.json" \
+  --marketplace-name spellbook-local \
+  --with-skills \
+  --with-marketplace
+rsync -a --delete "$SPELLBOOK_ROOT/plugins/spellbook-ui/" \
+  "$PILOT_ROOT/plugins/spellbook-ui/"
+codex plugin marketplace add "$PILOT_ROOT"
+codex plugin add spellbook-ui@spellbook-local
+```
+
+Start a new Codex thread after installation so the plugin skills are loaded.
+Remove the temporary marketplace when the pilot is finished:
+
+```bash
+codex plugin remove spellbook-ui
+codex plugin marketplace remove spellbook-local
+```
+
+These are local development instructions. They do not imply publication in an
+OpenAI or Spellbook marketplace.

--- a/plugins/spellbook-ui/skills/app-ui-design/SKILL.md
+++ b/plugins/spellbook-ui/skills/app-ui-design/SKILL.md
@@ -1,0 +1,417 @@
+---
+name: app-ui-design
+description: Mobile app UI design expert for iOS and Android. Use when designing app interfaces, creating design systems, ensuring accessibility, or following platform guidelines. Covers Material Design 3, Human Interface Guidelines, color theory, typography, and 2025 trends.
+---
+# Mobile App UI Design
+
+> Expert guidance for designing beautiful, accessible, and platform-native mobile app interfaces following 2025 best practices.
+
+## Core Philosophy
+
+- **User-First Design** — Prioritize user needs, behaviors, and mental models over aesthetics
+- **Platform Consistency** — Follow iOS HIG and Android Material Design guidelines
+- **Accessibility as Foundation** — Design for all users from the start, not as an afterthought
+- **Emotional Intelligence** — Create interfaces that users emotionally connect with
+- **Performance-Conscious** — Beautiful design that doesn't sacrifice app performance
+
+---
+
+## Hard Rules (Must Follow)
+
+> These rules are mandatory. Violating them means the skill is not working correctly.
+
+### Accessibility First
+
+**All designs must meet WCAG 2.2 AA standards. Accessibility is not optional.**
+
+```markdown
+❌ FORBIDDEN:
+- Color contrast below 4.5:1 for text
+- Touch targets smaller than 44×44pt (iOS) or 48×48dp (Android)
+- Information conveyed by color alone
+- Missing alternative text for images
+- Non-keyboard-navigable interfaces
+
+✅ REQUIRED:
+- Minimum 4.5:1 contrast ratio for normal text
+- Minimum 3:1 contrast ratio for large text (18pt+)
+- Touch targets: 44×44pt (iOS) / 48×48dp (Android)
+- Support for Dynamic Type / Font Scaling
+- VoiceOver (iOS) / TalkBack (Android) compatibility
+- Clear focus indicators for keyboard navigation
+```
+
+### Platform Guidelines Adherence
+
+**Follow platform-specific design guidelines. Do not mix iOS and Android patterns.**
+
+```markdown
+❌ FORBIDDEN:
+- Using Android-style FAB on iOS
+- Using iOS-style bottom sheets on Android without adaptation
+- Mixing platform navigation patterns
+- Ignoring platform typography (SF Pro vs Roboto)
+
+✅ REQUIRED:
+iOS (Human Interface Guidelines):
+- Use SF Pro font family
+- Tab bar at bottom for primary navigation
+- Push navigation with back chevron
+- Standard iOS controls (UIKit/SwiftUI)
+
+Android (Material Design 3):
+- Use Roboto font family
+- Bottom navigation bar or navigation drawer
+- Material components with ripple effects
+- Follow Material You dynamic theming
+```
+
+### Consistent Design System
+
+**Every app must have a documented design system with tokens.**
+
+```markdown
+❌ FORBIDDEN:
+- Ad-hoc colors and spacing values
+- Inconsistent button styles across screens
+- Multiple unnamed font sizes
+- Components without defined states
+
+✅ REQUIRED:
+Design System Must Include:
+├── Color Tokens (primary, secondary, surface, error, etc.)
+├── Typography Scale (heading1-6, body, caption, etc.)
+├── Spacing Scale (4, 8, 12, 16, 24, 32, 48px)
+├── Border Radius Tokens (none, sm, md, lg, full)
+├── Shadow/Elevation Tokens (elevation1-5)
+└── Component Library (button, input, card, etc.)
+```
+
+### Touch-Friendly Design
+
+**All interactive elements must be optimized for touch interaction.**
+
+```markdown
+❌ FORBIDDEN:
+- Touch targets smaller than minimum size
+- Interactive elements too close together (<8px gap)
+- Important actions outside thumb reach zone
+- Hover-dependent interactions
+
+✅ REQUIRED:
+- Minimum touch target: 44×44pt (iOS) / 48×48dp (Android)
+- Minimum spacing between targets: 8px
+- Primary actions in thumb-friendly zone (bottom 2/3)
+- Clear tap feedback (ripple, highlight, scale)
+```
+
+---
+
+## Quick Reference
+
+### When to Use What
+
+| Scenario | Approach | Key Considerations |
+|----------|----------|-------------------|
+| New app design | Start with design system | Define tokens before screens |
+| iOS-only app | Human Interface Guidelines | SF Pro, standard iOS patterns |
+| Android-only app | Material Design 3 | Roboto, Material components |
+| Cross-platform app | Adaptive design | Platform-specific navigation |
+| Redesign existing app | Audit first | Maintain mental models |
+| Accessibility review | WCAG 2.2 AA checklist | Contrast, touch targets, labels |
+
+---
+
+## Design System Fundamentals
+
+### Color System
+
+```markdown
+## Color Token Structure
+
+### Semantic Colors
+primary          → Main brand color, CTAs
+primary-variant  → Darker/lighter primary for states
+secondary        → Secondary actions, accents
+background       → App background
+surface          → Card backgrounds, elevated surfaces
+error            → Error states, destructive actions
+on-primary       → Text/icons on primary color
+on-background    → Text/icons on background
+on-surface       → Text/icons on surface
+
+### Color Palette (60-30-10 Rule)
+60% → Neutral/background colors
+30% → Secondary/supporting colors
+10% → Accent/primary colors
+
+### Dark Mode Considerations
+- Don't just invert colors
+- Use desaturated colors for dark surfaces
+- Reduce contrast slightly (avoid pure white on black)
+- Maintain color meaning across modes
+```
+
+### Typography Scale
+
+```markdown
+## Mobile Typography Guidelines
+
+### iOS Typography (SF Pro)
+Large Title   → 34pt, Bold
+Title 1       → 28pt, Bold
+Title 2       → 22pt, Bold
+Title 3       → 20pt, Semibold
+Headline      → 17pt, Semibold
+Body          → 17pt, Regular
+Callout       → 16pt, Regular
+Subhead       → 15pt, Regular
+Footnote      → 13pt, Regular
+Caption 1     → 12pt, Regular
+Caption 2     → 11pt, Regular
+
+### Android Typography (Roboto / Material 3)
+Display Large  → 57sp
+Display Medium → 45sp
+Display Small  → 36sp
+Headline Large → 32sp
+Headline Medium→ 28sp
+Headline Small → 24sp
+Title Large    → 22sp
+Title Medium   → 16sp, Medium
+Title Small    → 14sp, Medium
+Body Large     → 16sp
+Body Medium    → 14sp
+Body Small     → 12sp
+Label Large    → 14sp, Medium
+Label Medium   → 12sp, Medium
+Label Small    → 11sp, Medium
+
+### Best Practices
+- Maximum 2-3 font families per app
+- Minimum body text: 16px (14px absolute minimum)
+- Line height: 1.4-1.6× font size for body text
+- Support Dynamic Type (iOS) / Font Scaling (Android)
+```
+
+### Spacing System
+
+```markdown
+## 8-Point Grid System
+
+Base Unit: 8px
+
+### Spacing Scale
+spacing-0    → 0px
+spacing-1    → 4px   (half unit)
+spacing-2    → 8px   (1 unit)
+spacing-3    → 12px  (1.5 units)
+spacing-4    → 16px  (2 units)
+spacing-5    → 24px  (3 units)
+spacing-6    → 32px  (4 units)
+spacing-7    → 48px  (6 units)
+spacing-8    → 64px  (8 units)
+
+### Component Spacing
+Button padding      → 12px vertical, 24px horizontal
+Card padding        → 16px
+List item padding   → 16px horizontal, 12px vertical
+Section spacing     → 24px-32px
+Screen edge margin  → 16px (phones), 24px (tablets)
+
+### Touch Target Spacing
+Minimum gap between interactive elements: 8px
+Recommended gap: 12-16px
+```
+
+---
+
+## Platform Guidelines
+
+### iOS Human Interface Guidelines
+
+```markdown
+## iOS Design Principles
+
+### Core Principles
+1. Clarity    → Text legible, icons precise, purpose obvious
+2. Deference  → UI helps understanding, not competing with content
+3. Depth      → Visual layers and realistic motion convey hierarchy
+
+### Navigation Patterns
+- Tab Bar (bottom) → 3-5 primary destinations
+- Navigation Bar (top) → Title, back button, actions
+- Modal sheets → Temporary focused tasks
+- Popovers (iPad) → Contextual options
+
+### 2025 Updates: Liquid Glass
+- Translucent materials for controls
+- Floating navigation elements
+- Dynamic depth and hierarchy
+- Background blur effects
+
+### Safe Areas
+- Top: Status bar + Dynamic Island/Notch
+- Bottom: Home indicator (34pt on Face ID devices)
+- Use safeAreaInsets for proper content placement
+
+### Standard Dimensions
+- Navigation bar height: 44pt (96pt with large title)
+- Tab bar height: 49pt (83pt on Face ID devices)
+- Toolbar height: 44pt
+```
+
+### Android Material Design 3
+
+```markdown
+## Material Design 3 Principles
+
+### Core Concepts
+1. Material You    → Personal, adaptive, dynamic color
+2. Expressiveness  → Emotional connection through design
+3. Accessibility   → Inclusive design for all users
+
+### Navigation Patterns
+- Bottom Navigation → 3-5 primary destinations
+- Navigation Drawer → 5+ destinations or secondary nav
+- Navigation Rail → Tablets and large screens
+- Top App Bar → Title, navigation, actions
+
+### Material 3 Expressive (2025)
+- Dynamic color from user wallpaper
+- Springy, physics-based motion
+- Bolder, more expressive typography
+- Rounded, approachable shapes
+
+### Component Shapes
+- Extra Small: 4dp
+- Small: 8dp
+- Medium: 12dp
+- Large: 16dp
+- Extra Large: 28dp
+- Full: 50% (pills/circles)
+
+### Standard Dimensions
+- App bar height: 64dp
+- Bottom navigation height: 80dp
+- FAB size: 56dp (standard), 40dp (small), 96dp (large)
+```
+
+---
+
+## 2025 Design Trends
+
+### AI-Driven Personalization
+
+```markdown
+## Adaptive UI Patterns
+
+### Personalization Strategies
+- Content recommendations based on behavior
+- Adaptive UI layouts based on usage patterns
+- Smart defaults and predictive actions
+- Contextual feature suggestions
+
+### Implementation Guidelines
+- Always provide manual override options
+- Explain why content is recommended
+- Respect user privacy preferences
+- Gradual personalization (don't overwhelm new users)
+```
+
+### Dark Mode Excellence
+
+```markdown
+## Dark Mode Best Practices
+
+### Color Adaptation
+Light Mode          →    Dark Mode
+White (#FFFFFF)     →    Dark gray (#121212)
+Black (#000000)     →    White (#FFFFFF)
+Primary (vibrant)   →    Primary (desaturated)
+Shadows             →    Subtle shadows or none
+
+### Surface Elevation (Material 3)
+Elevation 0  → #121212
+Elevation 1  → #1E1E1E (+ 5% white overlay)
+Elevation 2  → #232323 (+ 7% white overlay)
+Elevation 3  → #272727 (+ 8% white overlay)
+Elevation 4  → #2C2C2C (+ 9% white overlay)
+Elevation 5  → #323232 (+ 11% white overlay)
+
+### Recommendations
+- Auto-switch based on system setting
+- Separate color tokens for light/dark
+- Test contrast in both modes
+- Consider OLED optimization (true blacks)
+```
+
+### Microinteractions
+
+```markdown
+## Meaningful Motion
+
+### Types of Microinteractions
+- Feedback → Button press, form submission
+- State → Loading, success, error
+- Guidance → Onboarding hints, tooltips
+- Delight → Celebration animations, easter eggs
+
+### Motion Principles
+- Duration: 200-500ms for most interactions
+- Easing: Use natural easing curves
+- Purpose: Every animation should have a reason
+- Performance: Use hardware-accelerated properties
+
+### 2025 Trends
+- Springy, physics-based animations
+- Morphing transitions between states
+- Gesture-driven interactions
+- Reduced motion support for accessibility
+```
+
+### Glassmorphism & Neumorphism
+
+```markdown
+## Modern Visual Styles
+
+### Glassmorphism
+Properties:
+- Background blur (backdrop-filter: blur)
+- Transparency (10-40% opacity)
+- Subtle border (1px white at 20% opacity)
+- Soft shadow
+
+Use Cases:
+- Overlays and modals
+- Cards on image backgrounds
+- Navigation bars (iOS Liquid Glass)
+
+Caution:
+- Ensure text readability
+- Consider performance impact
+- Provide fallback for older devices
+
+### Neumorphism (Soft UI)
+Properties:
+- Soft shadows (light and dark)
+- Subtle elevation effect
+- Muted color palette
+
+Use Cases:
+- Toggle switches
+- Input fields
+- Cards
+
+Caution:
+- Often fails accessibility contrast tests
+- Use sparingly, not as primary style
+- Always test with actual content
+```
+
+---
+
+
+## Extended Reference
+
+Detailed material starting at `## Accessibility Checklist` has been moved to [`reference/extended.md`](reference/extended.md) to keep this skill concise. Load that reference when the task requires the moved examples, command catalogs, checklists, platform details, or implementation templates.

--- a/plugins/spellbook-ui/skills/app-ui-design/reference/accessibility.md
+++ b/plugins/spellbook-ui/skills/app-ui-design/reference/accessibility.md
@@ -1,0 +1,472 @@
+# Mobile Accessibility Guidelines
+
+WCAG 2.2 AA compliance checklist for mobile app design.
+
+## POUR Principles
+
+### Perceivable
+Content must be presentable in ways users can perceive.
+
+### Operable
+Interface must be operable by all users.
+
+### Understandable
+Information and UI must be understandable.
+
+### Robust
+Content must work with assistive technologies.
+
+---
+
+## Visual Accessibility
+
+### Color Contrast
+
+| Element | Minimum Ratio | Tool |
+|---------|---------------|------|
+| Normal text (<18pt) | 4.5:1 | WebAIM Contrast Checker |
+| Large text (≥18pt or 14pt bold) | 3:1 | Stark (Figma plugin) |
+| UI components | 3:1 | Color Oracle |
+| Focus indicators | 3:1 | - |
+
+```markdown
+## Contrast Examples
+
+Good ✓
+├── Black (#000000) on White (#FFFFFF) = 21:1
+├── Dark Gray (#333333) on White (#FFFFFF) = 12.6:1
+└── Blue (#0066CC) on White (#FFFFFF) = 5.3:1
+
+Bad ✗
+├── Light Gray (#999999) on White (#FFFFFF) = 2.8:1
+├── Yellow (#FFFF00) on White (#FFFFFF) = 1.07:1
+└── Green (#00FF00) on White (#FFFFFF) = 1.37:1
+```
+
+### Color Independence
+
+Never use color as the only means of conveying information.
+
+```markdown
+❌ Bad:
+"Fields marked in red are required"
+(Users with colorblindness can't identify)
+
+✅ Good:
+"Required fields are marked with *"
++ Red color for additional emphasis
++ Error icon next to invalid fields
+```
+
+### Text Sizing
+
+| Platform | Minimum | Recommended | Support |
+|----------|---------|-------------|---------|
+| iOS | 11pt | 17pt body | Dynamic Type |
+| Android | 12sp | 16sp body | Font Scaling |
+
+```markdown
+## Font Scaling Support
+
+Must support:
+├── 100% (default)
+├── 150% (medium scaling)
+├── 200% (large scaling)
+└── 250%+ (extra large, if possible)
+
+All content must remain readable and usable at 200% scaling.
+```
+
+### Focus Indicators
+
+```markdown
+Requirements:
+- Visible focus ring on all interactive elements
+- Minimum 2px width
+- 3:1 contrast against adjacent colors
+- Consistent across app
+
+Example CSS-like styling:
+focus: {
+  outline: 2px solid #0066CC
+  outlineOffset: 2px
+}
+```
+
+---
+
+## Motor Accessibility
+
+### Touch Targets
+
+| Platform | Minimum Size | Recommended |
+|----------|--------------|-------------|
+| iOS | 44×44pt | 48×48pt |
+| Android | 48×48dp | 48×48dp |
+| Web (mobile) | 44×44px | 48×48px |
+
+```markdown
+## Target Spacing
+
+Minimum gap between targets: 8px
+Recommended gap: 12-16px
+
+┌────────────────────────────────────────┐
+│                                        │
+│  ┌─────────┐   8px+   ┌─────────┐     │
+│  │  44pt   │   gap    │  44pt   │     │
+│  │ Button  │ ←─────→ │ Button  │     │
+│  └─────────┘          └─────────┘     │
+│                                        │
+└────────────────────────────────────────┘
+```
+
+### Gesture Alternatives (WCAG 2.2)
+
+```markdown
+For every gesture-based action, provide an alternative:
+
+Gesture → Alternative
+─────────────────────────────────────────
+Swipe to delete → Tap to reveal delete button
+Pinch to zoom → Zoom +/- buttons
+Drag to reorder → Tap to move up/down
+Long press → Tap for options button
+Two-finger scroll → Single finger scroll
+Drawing gesture → Button to perform action
+```
+
+### Timing
+
+```markdown
+Requirements:
+- No time limits on actions (or extendable)
+- Auto-advancing content can be paused
+- Session timeouts warn user with extension option
+
+❌ Bad: Form submits automatically after 30 seconds
+✅ Good: User controls when to submit
+```
+
+---
+
+## Cognitive Accessibility
+
+### Clear Labels
+
+```markdown
+Every form input needs:
+1. Visible label (not placeholder only)
+2. Associated label (for screen readers)
+3. Clear instructions if needed
+4. Error messages that explain the fix
+
+❌ Bad:
+┌─────────────────────────┐
+│ Email                   │  ← Placeholder disappears
+└─────────────────────────┘
+
+✅ Good:
+Email *
+┌─────────────────────────┐
+│ example@email.com       │  ← Placeholder as hint
+└─────────────────────────┘
+Enter your work email address
+```
+
+### Error Messages
+
+```markdown
+Error messages must:
+1. Identify the field with error
+2. Explain what went wrong
+3. Suggest how to fix it
+
+❌ Bad: "Invalid input"
+✅ Good: "Email address must include @"
+
+❌ Bad: "Error"
+✅ Good: "Password must be at least 8 characters"
+```
+
+### Consistent Navigation
+
+```markdown
+Navigation must be:
+- Consistent across all screens
+- Predictable in behavior
+- Clear in current location
+
+┌──────────────────────────────────┐
+│  ← Back     Profile    ⚙️       │  Consistent header
+├──────────────────────────────────┤
+│                                  │
+│         Page Content             │
+│                                  │
+├──────────────────────────────────┤
+│  🏠    🔍    ➕    👤           │  Consistent footer
+│        Active indicator          │
+└──────────────────────────────────┘
+```
+
+---
+
+## Screen Reader Support
+
+### Required Labels
+
+```markdown
+## iOS (VoiceOver)
+
+Every interactive element needs:
+├── accessibilityLabel → What it is
+├── accessibilityHint → What happens when activated
+├── accessibilityTraits → Type (button, link, etc.)
+└── accessibilityValue → Current value (if applicable)
+
+SwiftUI Example:
+Button("Add to cart") { }
+  .accessibilityLabel("Add to cart")
+  .accessibilityHint("Adds this item to your shopping cart")
+
+## Android (TalkBack)
+
+contentDescription → What it is
+stateDescription → Current state
+roleDescription → Type override
+accessibilityLiveRegion → For dynamic content
+
+Compose Example:
+Button(
+  onClick = { },
+  modifier = Modifier.semantics {
+    contentDescription = "Add to cart"
+  }
+) { Text("Add") }
+```
+
+### Heading Structure
+
+```markdown
+Use proper heading hierarchy for navigation:
+
+Screen Title (Heading 1)
+├── Section A (Heading 2)
+│   ├── Subsection A.1 (Heading 3)
+│   └── Subsection A.2 (Heading 3)
+└── Section B (Heading 2)
+    └── Content
+
+iOS: accessibilityTraits = .header
+Android: heading = true
+```
+
+### Reading Order
+
+```markdown
+Ensure logical reading order matches visual order:
+
+1. Top to bottom
+2. Left to right (or right to left for RTL)
+3. Group related elements
+
+Test by:
+- Using screen reader
+- Checking tab order
+- Verifying announcements make sense
+```
+
+### Dynamic Content
+
+```markdown
+Announce changes to screen:
+
+iOS:
+UIAccessibility.post(notification: .announcement, argument: "Item added")
+
+Android:
+View.announceForAccessibility("Item added")
+
+Use for:
+├── Loading states
+├── Error messages
+├── Success confirmations
+├── Content updates
+└── Navigation changes
+```
+
+---
+
+## Platform Features
+
+### iOS Accessibility Features
+
+```markdown
+Support these system features:
+├── Dynamic Type → Scalable text
+├── Bold Text → Heavier font weights
+├── Increase Contrast → Higher contrast UI
+├── Reduce Motion → Minimize animations
+├── Reduce Transparency → Solid backgrounds
+├── VoiceOver → Screen reader
+├── Switch Control → Physical switch navigation
+├── Voice Control → Voice commands
+└── AssistiveTouch → Custom gestures
+```
+
+### Android Accessibility Features
+
+```markdown
+Support these system features:
+├── Font size → Text scaling
+├── Display size → UI scaling
+├── High contrast text → Enhanced contrast
+├── Color correction → Colorblind modes
+├── Color inversion → Dark mode alternative
+├── TalkBack → Screen reader
+├── Switch Access → Physical switch navigation
+├── Voice Access → Voice commands
+└── BrailleBack → Braille display support
+```
+
+---
+
+## Testing Checklist
+
+### Automated Testing
+
+```markdown
+□ Run accessibility scanner
+  - iOS: Accessibility Inspector
+  - Android: Accessibility Scanner app
+
+□ Check contrast ratios
+  - WebAIM Contrast Checker
+  - Stark plugin
+
+□ Validate focus order
+  - Use keyboard navigation
+  - Check logical sequence
+```
+
+### Manual Testing
+
+```markdown
+## Screen Reader Testing
+
+□ VoiceOver (iOS)
+  - Enable: Settings > Accessibility > VoiceOver
+  - Navigate entire app
+  - Verify all elements announced
+  - Check announcement clarity
+
+□ TalkBack (Android)
+  - Enable: Settings > Accessibility > TalkBack
+  - Navigate entire app
+  - Verify all elements announced
+  - Check announcement clarity
+
+## Motor Testing
+
+□ Keyboard navigation (external keyboard)
+  - Tab through all elements
+  - Activate with Enter/Space
+  - Use arrow keys where appropriate
+
+□ Switch Control
+  - Navigate and activate all features
+  - No time-dependent actions
+```
+
+### User Testing
+
+```markdown
+Include users with disabilities:
+├── Vision impairments
+├── Motor impairments
+├── Cognitive differences
+├── Hearing impairments (for audio content)
+└── Temporary impairments (arm in cast, etc.)
+```
+
+---
+
+## Common Mistakes
+
+```markdown
+❌ Placeholder-only labels
+   Fix: Add visible label above input
+
+❌ Color-only indicators
+   Fix: Add icons, text, or patterns
+
+❌ Small touch targets
+   Fix: Minimum 44pt/48dp size
+
+❌ Missing alt text
+   Fix: Add descriptive labels to all images
+
+❌ Auto-playing media
+   Fix: Require user action to play
+
+❌ Motion without control
+   Fix: Respect "Reduce Motion" setting
+
+❌ Time limits
+   Fix: Allow extension or removal
+
+❌ Keyboard traps
+   Fix: Allow tab navigation in and out
+
+❌ Unclear focus
+   Fix: Visible focus indicator on all elements
+
+❌ Non-semantic structure
+   Fix: Use proper headings and landmarks
+```
+
+---
+
+## Quick Reference Card
+
+```
+┌─────────────────────────────────────────────────────────┐
+│              ACCESSIBILITY QUICK REFERENCE               │
+├─────────────────────────────────────────────────────────┤
+│                                                          │
+│  CONTRAST                                                │
+│  • Text: 4.5:1 (normal), 3:1 (large)                    │
+│  • UI components: 3:1                                    │
+│                                                          │
+│  TOUCH TARGETS                                           │
+│  • iOS: 44×44pt minimum                                  │
+│  • Android: 48×48dp minimum                              │
+│  • Spacing: 8px minimum gap                              │
+│                                                          │
+│  TEXT                                                    │
+│  • Support Dynamic Type / Font Scaling                   │
+│  • Must work at 200% zoom                                │
+│  • Visible labels, not placeholder-only                  │
+│                                                          │
+│  SCREEN READERS                                          │
+│  • Label all interactive elements                        │
+│  • Announce dynamic changes                              │
+│  • Logical reading order                                 │
+│                                                          │
+│  MOTION                                                  │
+│  • Respect Reduce Motion setting                         │
+│  • Provide alternatives to gestures                      │
+│  • No auto-playing content                               │
+│                                                          │
+└─────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Resources
+
+- [WCAG 2.2 Guidelines](https://www.w3.org/TR/WCAG22/)
+- [Apple Accessibility](https://developer.apple.com/accessibility/)
+- [Android Accessibility](https://developer.android.com/guide/topics/ui/accessibility)
+- [WebAIM Contrast Checker](https://webaim.org/resources/contrastchecker/)
+- [A11y Project Checklist](https://www.a11yproject.com/checklist/)

--- a/plugins/spellbook-ui/skills/app-ui-design/reference/color-theory.md
+++ b/plugins/spellbook-ui/skills/app-ui-design/reference/color-theory.md
@@ -1,0 +1,469 @@
+# Color Theory for Mobile Apps
+
+Essential color selection and usage guidelines for mobile app design.
+
+## Color Fundamentals
+
+### Color Properties
+
+```markdown
+HUE        → The color itself (red, blue, green)
+             Measured in degrees (0-360°)
+
+SATURATION → Color intensity/purity
+             0% = gray, 100% = pure color
+
+LIGHTNESS  → How light or dark
+             0% = black, 100% = white
+
+BRIGHTNESS → Perceived luminance
+             How much light appears to emit
+```
+
+### Color Wheel
+
+```
+              Yellow (60°)
+                  ●
+            /           \
+     Yellow-Green      Orange
+          /               \
+    Green ●               ● Red (0°/360°)
+          \               /
+       Cyan           Magenta
+            \         /
+                ●
+              Blue (240°)
+```
+
+---
+
+## Color Relationships
+
+### Monochromatic
+Single hue with varying saturation/lightness.
+
+```
+████████████████████████████████
+Light ←──────────────────→ Dark
+
+Use: Clean, professional, minimalist apps
+Example: Different shades of blue
+```
+
+### Complementary
+Colors opposite on the wheel (high contrast).
+
+```
+    ●──────────────●
+   Red            Cyan
+
+Use: CTAs, important elements, contrast
+Caution: Can be jarring if overused
+```
+
+### Analogous
+Adjacent colors on the wheel (harmonious).
+
+```
+        ● ● ●
+    Blue Cyan Green
+
+Use: Cohesive, calming palettes
+Example: Nature apps, wellness apps
+```
+
+### Triadic
+Three colors equally spaced (balanced variety).
+
+```
+          ●
+         /  \
+        /    \
+       ●──────●
+
+Use: Vibrant, balanced palettes
+Example: Red, Yellow, Blue (primary)
+```
+
+### Split-Complementary
+One color + two adjacent to its complement.
+
+```
+          ●
+         /|\
+        / | \
+       ●     ●
+
+Use: Contrast with less tension
+Example: Blue + Yellow-Orange + Red-Orange
+```
+
+---
+
+## The 60-30-10 Rule
+
+```markdown
+60% → Primary/Neutral color (backgrounds, large areas)
+30% → Secondary color (cards, sections, supporting)
+10% → Accent color (CTAs, icons, highlights)
+
+Example:
+┌────────────────────────────────────────────┐
+│                                            │
+│  ████████████████████████████████████████  │ 60% Light Gray
+│  ████████████████████████████████████████  │ (Background)
+│  ████████████████████████████████████████  │
+│                                            │
+│     ┌────────────────────────────────┐     │
+│     │  ████████████████████████████  │     │ 30% White
+│     │  ████████████████████████████  │     │ (Cards)
+│     │          ┌──────────┐          │     │
+│     │          │  Submit  │          │     │ 10% Blue
+│     │          └──────────┘          │     │ (CTA Button)
+│     └────────────────────────────────┘     │
+│                                            │
+└────────────────────────────────────────────┘
+```
+
+---
+
+## Semantic Colors
+
+### Standard Meanings
+
+| Color | Meaning | Use Cases |
+|-------|---------|-----------|
+| Blue | Trust, security, calm | Primary actions, links |
+| Green | Success, growth, go | Confirmations, positive |
+| Red | Error, danger, stop | Errors, destructive actions |
+| Yellow | Warning, caution | Alerts, warnings |
+| Orange | Energy, enthusiasm | Secondary CTAs, highlights |
+| Purple | Premium, creative | Luxury, creative apps |
+| Gray | Neutral, secondary | Text, borders, disabled |
+
+### Semantic Token Structure
+
+```markdown
+## Color Token Naming
+
+Semantic (Recommended):
+├── color-primary
+├── color-primary-variant
+├── color-secondary
+├── color-background
+├── color-surface
+├── color-error
+├── color-success
+├── color-warning
+├── color-on-primary
+├── color-on-background
+└── color-on-surface
+
+Avoid Literal Names:
+├── color-blue ← Don't use
+├── color-red ← Don't use
+└── color-green ← Don't use
+```
+
+---
+
+## Dark Mode Colors
+
+### Adaptation Principles
+
+```markdown
+DON'T just invert colors. Instead:
+
+1. Reduce saturation for dark surfaces
+2. Use elevation with lighter overlays
+3. Keep brand colors recognizable
+4. Test contrast in both modes
+
+Light Mode → Dark Mode
+───────────────────────────────────────
+White background → Dark gray (#121212), not pure black
+Black text → Light gray (#E0E0E0), not pure white
+Vibrant primary → Slightly desaturated primary
+White on colored → Dark on lighter colored
+```
+
+### Surface Elevation (Material 3)
+
+```markdown
+Dark Mode Surface Colors:
+
+Level 0: #121212 (base surface)
+Level 1: #1E1E1E (+ 5% white overlay)
+Level 2: #232323 (+ 7% white overlay)
+Level 3: #272727 (+ 8% white overlay)
+Level 4: #2C2C2C (+ 9% white overlay)
+Level 5: #323232 (+ 11% white overlay)
+
+Cards and elevated elements use higher levels
+to create visual hierarchy without shadows.
+```
+
+### OLED Optimization
+
+```markdown
+For OLED screens:
+- True black (#000000) saves battery
+- Use for backgrounds where appropriate
+- Avoid large areas of pure white
+- Test for "smearing" effect on scrolling
+
+Recommendation:
+Use near-black (#0A0A0A) instead of pure black
+for main backgrounds to reduce contrast issues.
+```
+
+---
+
+## Accessibility & Contrast
+
+### WCAG Contrast Requirements
+
+```markdown
+Minimum Contrast Ratios:
+
+Text (< 18pt / 14pt bold):     4.5:1  [AA]
+Large Text (≥ 18pt / 14pt bold): 3:1  [AA]
+UI Components:                   3:1  [AA]
+
+Enhanced (AAA):
+Text:       7:1
+Large Text: 4.5:1
+```
+
+### Color Contrast Examples
+
+```markdown
+Good Contrast ✓
+─────────────────────────────────────────
+#000000 on #FFFFFF → 21:1 (Excellent)
+#333333 on #FFFFFF → 12.6:1 (Excellent)
+#0066CC on #FFFFFF → 5.3:1 (Good for AA)
+#1A73E8 on #FFFFFF → 4.5:1 (Minimum AA)
+
+Poor Contrast ✗
+─────────────────────────────────────────
+#777777 on #FFFFFF → 4.5:1 (Borderline)
+#999999 on #FFFFFF → 2.8:1 (Fail)
+#AAAAAA on #FFFFFF → 2.3:1 (Fail)
+```
+
+### Colorblind Considerations
+
+```markdown
+Types of Color Blindness:
+├── Deuteranopia (red-green, most common)
+├── Protanopia (red-green)
+├── Tritanopia (blue-yellow, rare)
+└── Achromatopsia (complete, very rare)
+
+Guidelines:
+1. Don't rely on color alone
+2. Add icons, patterns, or text
+3. Test with color blindness simulators
+4. Avoid red/green combinations for distinctions
+
+Tools:
+- Color Oracle (desktop simulator)
+- Figma A11y plugin
+- Chrome DevTools → Rendering → Emulate
+```
+
+---
+
+## Brand Color Guidelines
+
+### Choosing Primary Color
+
+```markdown
+Considerations:
+1. Industry conventions
+2. Target audience expectations
+3. Cultural meanings
+4. Competitor differentiation
+5. Accessibility requirements
+
+Industry Trends:
+├── Finance: Blue (trust, security)
+├── Health: Green, Blue (calm, growth)
+├── Food: Red, Orange (appetite, energy)
+├── Luxury: Black, Gold, Purple (premium)
+├── Tech: Blue, Purple (innovation)
+└── Children: Bright, varied (fun)
+```
+
+### Creating a Palette
+
+```markdown
+Step 1: Choose primary color
+        ████████████
+        Brand Blue #1A73E8
+
+Step 2: Generate tonal variations
+        100 ██████████ Lightest
+        200 ██████████
+        300 ██████████
+        400 ██████████
+        500 ██████████ ← Primary
+        600 ██████████
+        700 ██████████
+        800 ██████████
+        900 ██████████ Darkest
+
+Step 3: Select secondary color
+        (Complementary or analogous)
+
+Step 4: Add semantic colors
+        (Error, warning, success)
+
+Step 5: Define neutrals
+        (Gray scale for text, borders)
+```
+
+### Palette Sizes
+
+```markdown
+Minimal Palette (Simple Apps):
+├── Primary (1 shade)
+├── Secondary (1 shade)
+├── Neutrals (3-5 grays)
+├── Error (red)
+└── Success (green)
+
+Standard Palette (Most Apps):
+├── Primary (5 tonal variations)
+├── Secondary (5 tonal variations)
+├── Tertiary (3 tonal variations)
+├── Neutrals (7-10 grays)
+├── Semantic (error, warning, success, info)
+└── Surfaces (light/dark backgrounds)
+
+Extended Palette (Complex Apps):
+├── Primary family (10 variations)
+├── Secondary family (10 variations)
+├── Tertiary family (10 variations)
+├── Extended neutrals
+├── Extended semantics
+└── Special purpose colors
+```
+
+---
+
+## 2025 Color Trends
+
+### Popular Palettes
+
+```markdown
+1. Muted & Desaturated
+   Soft, gentle colors with reduced saturation
+   ██████ #8B9A7D (Sage)
+   ██████ #B8A9C9 (Lavender)
+   ██████ #F2E8DC (Cream)
+
+2. Bold Gradients
+   Vibrant color transitions
+   ██████ → ██████ (Sunset: Orange to Pink)
+   ██████ → ██████ (Ocean: Blue to Teal)
+
+3. Neo-Brutalism
+   High contrast, bold primaries
+   ██████ #FF5733 (Bold Orange)
+   ██████ #000000 (Black)
+   ██████ #FFFFFF (White)
+
+4. Digital Nature
+   Tech meets organic
+   ██████ #0A6847 (Forest)
+   ██████ #7ABA78 (Leaf)
+   ██████ #F6E9B2 (Sand)
+```
+
+### Material You Dynamic Color
+
+```markdown
+Android 12+ extracts colors from wallpaper:
+
+User Wallpaper
+      ↓
+Color Extraction Algorithm
+      ↓
+├── Primary color
+├── Secondary color
+├── Tertiary color
+├── Neutral color
+└── Neutral variant
+
+App automatically adapts to user's palette.
+```
+
+---
+
+## Quick Reference
+
+### Color Token Template
+
+```json
+{
+  "colors": {
+    "primary": {
+      "main": "#1A73E8",
+      "light": "#4285F4",
+      "dark": "#1557B0",
+      "contrast": "#FFFFFF"
+    },
+    "secondary": {
+      "main": "#34A853",
+      "light": "#5BB974",
+      "dark": "#1E8E3E",
+      "contrast": "#FFFFFF"
+    },
+    "background": {
+      "default": "#FFFFFF",
+      "paper": "#F5F5F5"
+    },
+    "text": {
+      "primary": "#202124",
+      "secondary": "#5F6368",
+      "disabled": "#9AA0A6"
+    },
+    "error": "#D93025",
+    "warning": "#F9AB00",
+    "success": "#1E8E3E",
+    "info": "#1A73E8"
+  }
+}
+```
+
+### Contrast Checker Tools
+
+```markdown
+Online Tools:
+- WebAIM Contrast Checker
+- Coolors Contrast Checker
+- Color Review
+
+Design Tool Plugins:
+- Stark (Figma, Sketch)
+- A11y Color Contrast
+- Contrast (Figma)
+
+Browser DevTools:
+- Chrome: Inspect → Color picker
+- Firefox: Accessibility Inspector
+```
+
+---
+
+## Resources
+
+- [Coolors](https://coolors.co/) - Palette generator
+- [Adobe Color](https://color.adobe.com/) - Color wheel
+- [Realtime Colors](https://www.realtimecolors.com/) - Preview on mock UI
+- [Material Theme Builder](https://m3.material.io/theme-builder) - Material 3
+- [Paletton](https://paletton.com/) - Color scheme designer
+- [Color Hunt](https://colorhunt.co/) - Curated palettes

--- a/plugins/spellbook-ui/skills/app-ui-design/reference/extended.md
+++ b/plugins/spellbook-ui/skills/app-ui-design/reference/extended.md
@@ -1,0 +1,316 @@
+# app-ui-design Extended Reference
+
+This file preserves detailed material moved out of `SKILL.md` for progressive disclosure. Load it only when the current task needs the specific examples, commands, templates, or checklists below.
+
+Moved content starts at: `## Accessibility Checklist`.
+
+## Accessibility Checklist
+
+### Visual Accessibility
+
+```markdown
+## Vision Accessibility Checklist
+
+### Color & Contrast
+- [ ] Text contrast ≥ 4.5:1 (normal), ≥ 3:1 (large)
+- [ ] UI component contrast ≥ 3:1
+- [ ] Color is not the only indicator (use icons, text)
+- [ ] Works for colorblind users (test with simulators)
+
+### Text & Typography
+- [ ] Base font size ≥ 16px
+- [ ] Supports Dynamic Type (iOS) / Font Scaling (Android)
+- [ ] Line height ≥ 1.4× for body text
+- [ ] Text can scale to 200% without loss of content
+
+### Focus & Navigation
+- [ ] Visible focus indicators
+- [ ] Logical tab order
+- [ ] Skip links for repetitive content
+- [ ] Keyboard-accessible (external keyboards)
+```
+
+### Motor Accessibility
+
+```markdown
+## Motor Accessibility Checklist
+
+### Touch Targets
+- [ ] Minimum size: 44×44pt (iOS) / 48×48dp (Android)
+- [ ] Spacing between targets ≥ 8px
+- [ ] No time-limited interactions (or extendable)
+- [ ] Alternative to drag gestures (WCAG 2.2)
+
+### Interaction
+- [ ] Single-tap for all actions (no double-tap required)
+- [ ] Undo available for destructive actions
+- [ ] No precision requirements (fine motor)
+- [ ] Support for Switch Control / Voice Access
+```
+
+### Screen Reader
+
+```markdown
+## Screen Reader Checklist
+
+### Content
+- [ ] All images have descriptive alt text
+- [ ] Decorative images have empty alt (alt="")
+- [ ] Buttons/links have descriptive labels
+- [ ] Form inputs have associated labels
+- [ ] Headings used for structure (not styling)
+
+### Navigation
+- [ ] Logical reading order
+- [ ] Meaningful link text (not "click here")
+- [ ] State changes announced
+- [ ] Modal focus properly trapped
+- [ ] Custom components have ARIA roles
+```
+
+---
+
+## Component Patterns
+
+### Button Design
+
+```markdown
+## Button Hierarchy
+
+### Primary Button
+- Most important action on screen
+- Filled/solid style
+- High contrast
+- Only ONE per view section
+
+### Secondary Button
+- Alternative actions
+- Outlined or tonal style
+- Medium contrast
+
+### Tertiary Button
+- Low-priority actions
+- Text-only or ghost style
+- Subtle appearance
+
+### Destructive Button
+- Delete, remove, cancel
+- Red/error color
+- Requires confirmation for important data
+
+### Button States
+- Default → Normal appearance
+- Pressed → Scale down, darker
+- Disabled → 50% opacity, no interaction
+- Loading → Spinner, disabled
+```
+
+### Form Design
+
+```markdown
+## Form Best Practices
+
+### Input Fields
+- Clear labels (above input, not placeholder-only)
+- Helpful placeholder text
+- Error states with specific messages
+- Success validation feedback
+- Appropriate keyboard types
+
+### Layout
+- Single column for mobile
+- Group related fields
+- Logical tab order
+- Primary action at bottom
+- Sticky submit button if long form
+
+### Validation
+- Inline validation (on blur or after input)
+- Clear error messages with fix suggestions
+- Don't clear fields on error
+- Mark required fields clearly
+```
+
+### Navigation Patterns
+
+```markdown
+## Mobile Navigation
+
+### Bottom Navigation (Primary)
+- 3-5 destinations
+- Icons + labels
+- Active state indicator
+- Consistent across app
+
+### Tab Bar (Content Switching)
+- Horizontal tabs for related content
+- Swipe between tabs
+- Indicator for active tab
+
+### Navigation Stack
+- Clear back navigation
+- Meaningful titles
+- Breadcrumbs for deep hierarchies
+
+### Gestures
+- Swipe back (iOS standard)
+- Pull to refresh
+- Swipe actions on list items
+- Long press for context menus
+```
+
+---
+
+## Design Process
+
+### Workflow
+
+```markdown
+## App Design Workflow
+
+1. Research & Discovery
+   ├── User research and personas
+   ├── Competitor analysis
+   ├── Platform guidelines review
+   └── Technical constraints
+
+2. Information Architecture
+   ├── User flows
+   ├── Navigation structure
+   ├── Content hierarchy
+   └── Sitemap
+
+3. Design System Setup
+   ├── Color tokens
+   ├── Typography scale
+   ├── Spacing system
+   ├── Component library
+   └── Icon set
+
+4. Wireframing
+   ├── Low-fidelity layouts
+   ├── Flow validation
+   ├── Stakeholder review
+   └── Iteration
+
+5. Visual Design
+   ├── High-fidelity mockups
+   ├── Interaction design
+   ├── Prototype creation
+   └── Accessibility audit
+
+6. Handoff & Implementation
+   ├── Design specs documentation
+   ├── Asset export
+   ├── Developer collaboration
+   └── QA review
+```
+
+---
+
+## Anti-Patterns to Avoid
+
+```markdown
+## Common Mistakes
+
+### Visual Design
+❌ Using more than 3 fonts
+❌ Inconsistent spacing values
+❌ Low contrast text
+❌ Overly complex gradients/effects
+❌ Ignoring safe areas
+
+### Interaction Design
+❌ Hidden navigation
+❌ Gesture-only actions without alternatives
+❌ Tiny touch targets
+❌ No loading states
+❌ Confusing back navigation
+
+### Accessibility
+❌ Placeholder-only labels
+❌ Color-only information
+❌ Auto-playing media
+❌ Timed interactions without extension
+❌ Missing screen reader labels
+
+### Platform
+❌ iOS patterns on Android (or vice versa)
+❌ Custom controls when standard works
+❌ Ignoring platform conventions
+❌ Not supporting dark mode
+```
+
+---
+
+## Checklist
+
+### Before Design
+- [ ] Reviewed platform guidelines (iOS HIG / Material Design 3)
+- [ ] Defined target users and their needs
+- [ ] Analyzed competitor apps
+- [ ] Identified accessibility requirements
+- [ ] Set up design system tokens
+
+### During Design
+- [ ] Following 8-point grid
+- [ ] Using defined color tokens
+- [ ] Typography from scale only
+- [ ] Touch targets meet minimum size
+- [ ] Contrast ratios verified
+- [ ] All states designed (default, pressed, disabled, error)
+- [ ] Dark mode variant created
+
+### Before Handoff
+- [ ] Accessibility audit completed
+- [ ] Tested with screen reader
+- [ ] Verified on multiple screen sizes
+- [ ] Motion/animation documented
+- [ ] Design specs annotated
+- [ ] Assets exported correctly
+
+---
+
+## Tools & Resources
+
+### Design Tools
+- Figma → Industry standard, collaboration
+- Sketch → Mac-native, established ecosystem
+- Adobe XD → Adobe integration
+
+### Prototyping
+- Figma Prototyping → Built-in, quick
+- ProtoPie → Advanced interactions
+- Principle → Mac, detailed animations
+
+### Accessibility Testing
+- Stark → Contrast checker (Figma plugin)
+- Color Oracle → Colorblind simulator
+- VoiceOver (iOS) / TalkBack (Android)
+
+### Platform Resources
+- [Apple Human Interface Guidelines](https://developer.apple.com/design/human-interface-guidelines/)
+- [Google Material Design](https://m3.material.io/)
+- [WCAG 2.2 Guidelines](https://www.w3.org/TR/WCAG22/)
+
+---
+
+## See Also
+
+- [reference/ios-guidelines.md](reference/ios-guidelines.md) — iOS Human Interface Guidelines summary
+- [reference/material-design.md](reference/material-design.md) — Material Design 3 summary
+- [reference/accessibility.md](reference/accessibility.md) — WCAG 2.2 mobile checklist
+- [reference/color-theory.md](reference/color-theory.md) — Color selection and contrast
+- [templates/design-system-template.md](templates/design-system-template.md) — Design system starter
+
+---
+
+## Sources
+
+Research based on 2025 best practices from:
+- [Mobile App UI Design Best Practices 2025](https://wezom.com/blog/mobile-app-design-best-practices-in-2025)
+- [UI/UX Design Trends 2025](https://www.chopdawg.com/ui-ux-design-trends-in-mobile-apps-for-2025/)
+- [Mobile App Design Trends 2025](https://fuselabcreative.com/mobile-app-design-trends-for-2025/)
+- [Accessibility in UI/UX Design 2025](https://orbix.studio/blogs/accessibility-uiux-design-best-practices-2025)
+- [iOS Design Guidelines 2025](https://www.bairesdev.com/blog/ios-design-guideline/)
+- [Mobile App Design Guidelines iOS/Android](https://medium.com/@CarlosSmith24/mobile-app-design-guidelines-for-ios-and-android-in-2025-82e83f0b942b)

--- a/plugins/spellbook-ui/skills/app-ui-design/reference/ios-guidelines.md
+++ b/plugins/spellbook-ui/skills/app-ui-design/reference/ios-guidelines.md
@@ -1,0 +1,313 @@
+# iOS Human Interface Guidelines
+
+Quick reference for iOS app design following Apple's Human Interface Guidelines (2025).
+
+## Design Principles
+
+### Clarity
+- Text must be legible at every size
+- Icons must be precise and understandable
+- Adornments must be subtle and appropriate
+- Focus on functionality drives design
+
+### Deference
+- Fluid motion and crisp interface help understanding
+- Content fills the screen
+- Translucency and blur hint at more content
+- Minimal use of bezels, gradients, and shadows
+
+### Depth
+- Distinct visual layers convey hierarchy
+- Transitions provide sense of depth
+- Touch and discoverability enhance delight
+
+## Typography
+
+### SF Pro Font Family
+
+| Style | Size | Weight | Use Case |
+|-------|------|--------|----------|
+| Large Title | 34pt | Bold | Screen titles, first visible element |
+| Title 1 | 28pt | Bold | Major section headers |
+| Title 2 | 22pt | Bold | Secondary headers |
+| Title 3 | 20pt | Semibold | Tertiary headers |
+| Headline | 17pt | Semibold | List item titles |
+| Body | 17pt | Regular | Main content text |
+| Callout | 16pt | Regular | Supplementary text |
+| Subhead | 15pt | Regular | Metadata |
+| Footnote | 13pt | Regular | Small details |
+| Caption 1 | 12pt | Regular | Image captions |
+| Caption 2 | 11pt | Regular | Timestamps |
+
+### Dynamic Type Support
+
+Always support Dynamic Type for accessibility:
+
+```swift
+// SwiftUI
+Text("Hello")
+    .font(.body) // Automatically scales
+
+// UIKit
+label.font = UIFont.preferredFont(forTextStyle: .body)
+label.adjustsFontForContentSizeCategory = true
+```
+
+## Layout & Spacing
+
+### Safe Areas
+
+```
+┌──────────────────────────────────┐
+│         Status Bar (47pt)        │  ← Top safe area
+├──────────────────────────────────┤
+│                                  │
+│                                  │
+│         Content Area             │
+│                                  │
+│                                  │
+├──────────────────────────────────┤
+│     Home Indicator (34pt)        │  ← Bottom safe area
+└──────────────────────────────────┘
+```
+
+### Standard Margins
+
+| Element | Margin |
+|---------|--------|
+| Screen edge (iPhone) | 16pt |
+| Screen edge (iPad) | 20pt |
+| Between sections | 35pt |
+| Between related elements | 8pt |
+
+### Touch Targets
+
+- **Minimum size**: 44×44pt
+- **Recommended size**: 48×48pt for primary actions
+- **Spacing between targets**: 8pt minimum
+
+## Navigation
+
+### Tab Bar
+
+```
+┌──────────────────────────────────┐
+│         Content Area             │
+├──────────────────────────────────┤
+│  🏠    🔍    ➕    ❤️    👤  │
+│ Home Search  Add  Favs Profile  │
+└──────────────────────────────────┘
+Height: 49pt (83pt on Face ID devices)
+```
+
+- 3-5 tabs maximum
+- Always show labels
+- Use SF Symbols for icons
+- Highlight active tab with fill or tint
+
+### Navigation Bar
+
+```
+┌──────────────────────────────────┐
+│  ‹ Back       Title        Edit  │
+│  (or Menu)                       │
+└──────────────────────────────────┘
+Height: 44pt (96pt with large title)
+```
+
+- Large title: Use for primary screens
+- Standard title: Use for secondary screens
+- Back button shows previous screen title (truncated)
+
+### Sheets & Modals
+
+```
+Types:
+- Sheet (.sheet) → Partial screen, swipe to dismiss
+- Full Screen (.fullScreenCover) → Complete takeover
+- Popover (iPad) → Contextual floating panel
+- Alert → Critical information, requires action
+```
+
+## Components
+
+### Buttons
+
+| Type | Appearance | Use Case |
+|------|------------|----------|
+| Filled | Solid background | Primary action |
+| Gray | Gray background | Secondary action |
+| Tinted | Colored text | Tertiary action |
+| Plain | Text only | Navigation, links |
+| Borderless | Icon only | Toolbar actions |
+
+### Lists
+
+```swift
+List {
+    Section("Section Header") {
+        ForEach(items) { item in
+            HStack {
+                Image(systemName: item.icon)
+                VStack(alignment: .leading) {
+                    Text(item.title)
+                    Text(item.subtitle)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+}
+```
+
+- Use standard row height (44pt minimum)
+- Group related items in sections
+- Provide swipe actions for common tasks
+- Support pull-to-refresh when appropriate
+
+### Text Fields
+
+```
+┌──────────────────────────────────┐
+│  Label                           │
+│  ┌────────────────────────────┐  │
+│  │ Placeholder text           │  │
+│  └────────────────────────────┘  │
+│  Helper text or error message    │
+└──────────────────────────────────┘
+```
+
+- Clear button on right
+- Show appropriate keyboard type
+- Support password autofill
+- Indicate required fields
+
+## Colors
+
+### System Colors
+
+```swift
+// Semantic colors (adapt to light/dark mode)
+Color.primary      // Primary text
+Color.secondary    // Secondary text
+Color.accentColor  // App tint color
+
+// System colors
+Color.red          // #FF3B30
+Color.orange       // #FF9500
+Color.yellow       // #FFCC00
+Color.green        // #34C759
+Color.mint         // #00C7BE
+Color.teal         // #30B0C7
+Color.cyan         // #32ADE6
+Color.blue         // #007AFF
+Color.indigo       // #5856D6
+Color.purple       // #AF52DE
+Color.pink         // #FF2D55
+Color.brown        // #A2845E
+```
+
+### Dark Mode
+
+```swift
+// Backgrounds
+Color(.systemBackground)       // White / Black
+Color(.secondarySystemBackground)  // Light gray / Dark gray
+Color(.tertiarySystemBackground)   // Darker variations
+
+// Always use semantic colors for automatic adaptation
+```
+
+## 2025: Liquid Glass
+
+Apple's new design language introduces:
+
+### Characteristics
+- **Translucency**: Background content visible through controls
+- **Depth**: Floating elements with subtle shadows
+- **Dynamic materials**: Responsive to underlying content
+- **Vibrancy**: Text and icons adjust based on background
+
+### Usage
+```swift
+// Apply glass effect
+.background(.ultraThinMaterial)
+.background(.regularMaterial)
+.background(.thickMaterial)
+```
+
+## Icons
+
+### SF Symbols
+
+- Use SF Symbols for consistency
+- Match symbol weight to text weight
+- Use rendering modes appropriately:
+  - Monochrome: Single color
+  - Hierarchical: Primary/secondary emphasis
+  - Palette: Custom colors
+  - Multicolor: Original colors
+
+```swift
+Image(systemName: "heart.fill")
+    .symbolRenderingMode(.hierarchical)
+    .foregroundStyle(.red)
+```
+
+## Gestures
+
+### Standard Gestures
+
+| Gesture | Action |
+|---------|--------|
+| Tap | Select, activate |
+| Long press | Preview, context menu |
+| Swipe (edge) | Back navigation |
+| Swipe (list item) | Quick actions |
+| Pull down | Refresh, dismiss sheet |
+| Pinch | Zoom |
+| Rotate | Rotate content |
+
+### Best Practices
+- Always provide alternative for gestures
+- Don't override system gestures
+- Provide haptic feedback for actions
+
+## Accessibility
+
+### Requirements
+- [ ] VoiceOver labels for all interactive elements
+- [ ] Dynamic Type support (up to xxxLarge)
+- [ ] Sufficient color contrast (4.5:1 minimum)
+- [ ] Reduce Motion support
+- [ ] High Contrast mode support
+- [ ] Button Shapes support
+
+```swift
+Button("Submit") {
+    submit()
+}
+.accessibilityLabel("Submit form")
+.accessibilityHint("Double tap to submit your information")
+```
+
+## Device Considerations
+
+### Screen Sizes (Points)
+
+| Device | Width | Height | Safe Areas |
+|--------|-------|--------|------------|
+| iPhone SE | 375 | 667 | Top: 20, Bottom: 0 |
+| iPhone 14 | 390 | 844 | Top: 47, Bottom: 34 |
+| iPhone 14 Pro | 393 | 852 | Top: 59, Bottom: 34 |
+| iPhone 14 Plus | 428 | 926 | Top: 47, Bottom: 34 |
+| iPhone 15 Pro Max | 430 | 932 | Top: 59, Bottom: 34 |
+| iPad Mini | 744 | 1133 | Varies |
+| iPad Pro 11" | 834 | 1194 | Varies |
+| iPad Pro 12.9" | 1024 | 1366 | Varies |
+
+### Design Recommendations
+- Start with iPhone 14 (390×844)
+- Use Auto Layout / SwiftUI for adaptivity
+- Test on smallest and largest devices
+- Consider landscape orientation

--- a/plugins/spellbook-ui/skills/app-ui-design/reference/material-design.md
+++ b/plugins/spellbook-ui/skills/app-ui-design/reference/material-design.md
@@ -1,0 +1,402 @@
+# Material Design 3 Guidelines
+
+Quick reference for Android app design following Google's Material Design 3 (2025).
+
+## Design Principles
+
+### Material You
+- **Personal**: Adapts to user preferences
+- **Adaptive**: Responds to device and context
+- **Expressive**: Communicates brand and emotion
+
+### Core Concepts
+- Surfaces over layers
+- Motion with meaning
+- Color from user wallpaper
+- Accessibility built-in
+
+## Typography
+
+### Roboto Font Family
+
+| Role | Size | Weight | Line Height | Tracking |
+|------|------|--------|-------------|----------|
+| Display Large | 57sp | Regular | 64sp | -0.25sp |
+| Display Medium | 45sp | Regular | 52sp | 0sp |
+| Display Small | 36sp | Regular | 44sp | 0sp |
+| Headline Large | 32sp | Regular | 40sp | 0sp |
+| Headline Medium | 28sp | Regular | 36sp | 0sp |
+| Headline Small | 24sp | Regular | 32sp | 0sp |
+| Title Large | 22sp | Regular | 28sp | 0sp |
+| Title Medium | 16sp | Medium | 24sp | 0.15sp |
+| Title Small | 14sp | Medium | 20sp | 0.1sp |
+| Body Large | 16sp | Regular | 24sp | 0.5sp |
+| Body Medium | 14sp | Regular | 20sp | 0.25sp |
+| Body Small | 12sp | Regular | 16sp | 0.4sp |
+| Label Large | 14sp | Medium | 20sp | 0.1sp |
+| Label Medium | 12sp | Medium | 16sp | 0.5sp |
+| Label Small | 11sp | Medium | 16sp | 0.5sp |
+
+### Font Scaling
+
+```kotlin
+// Support system font scaling
+Text(
+    text = "Hello",
+    style = MaterialTheme.typography.bodyLarge
+)
+```
+
+## Color System
+
+### Dynamic Color (Material You)
+
+Material You extracts colors from user's wallpaper:
+
+```
+┌─────────────────────────────────────────┐
+│            User Wallpaper                │
+│               🖼️                         │
+└─────────────────────────────────────────┘
+                    ↓
+┌─────────────────────────────────────────┐
+│  Primary    Secondary   Tertiary        │
+│  ████████   ████████   ████████         │
+│                                         │
+│  Neutral    NeutralVar  Error           │
+│  ████████   ████████   ████████         │
+└─────────────────────────────────────────┘
+```
+
+### Color Roles
+
+| Role | Light | Dark | Usage |
+|------|-------|------|-------|
+| Primary | Tonal 40 | Tonal 80 | Key components, FAB, active states |
+| On Primary | Tonal 100 | Tonal 20 | Text/icons on primary |
+| Primary Container | Tonal 90 | Tonal 30 | Less emphasis containers |
+| On Primary Container | Tonal 10 | Tonal 90 | Text/icons on container |
+| Secondary | Tonal 40 | Tonal 80 | Less prominent components |
+| Tertiary | Tonal 40 | Tonal 80 | Contrasting accents |
+| Surface | Neutral 99 | Neutral 10 | Backgrounds, cards |
+| On Surface | Neutral 10 | Neutral 90 | Body text |
+| Surface Variant | NeutralVar 90 | NeutralVar 30 | Decorative elements |
+| Outline | NeutralVar 50 | NeutralVar 60 | Dividers, borders |
+| Error | Error 40 | Error 80 | Error states |
+
+### Tonal Palette
+
+```
+Tonal values: 0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 95, 99, 100
+
+0   = Black
+100 = White
+
+Light mode typically uses: 40 (primary), 90 (container)
+Dark mode typically uses: 80 (primary), 30 (container)
+```
+
+## Elevation
+
+### Surface Tones
+
+Material 3 uses tonal elevation instead of shadows:
+
+```
+┌────────────────────────────────────────────┐
+│ Level  │ Elevation │ Tonal Offset          │
+├────────────────────────────────────────────┤
+│ 0      │ 0dp       │ Surface color         │
+│ 1      │ 1dp       │ +5% primary           │
+│ 2      │ 3dp       │ +8% primary           │
+│ 3      │ 6dp       │ +11% primary          │
+│ 4      │ 8dp       │ +12% primary          │
+│ 5      │ 12dp      │ +14% primary          │
+└────────────────────────────────────────────┘
+```
+
+### When to Use Elevation
+
+- Level 0: Page backgrounds
+- Level 1: Cards, sheets
+- Level 2: Navigation bars
+- Level 3: FABs, dialogs
+- Level 4: Search bars
+- Level 5: Snackbars, tooltips
+
+## Shape
+
+### Shape Scale
+
+| Size | Corner Radius | Use Case |
+|------|---------------|----------|
+| None | 0dp | Dividers, full-bleed images |
+| Extra Small | 4dp | Small chips, compact elements |
+| Small | 8dp | Buttons, text fields |
+| Medium | 12dp | Cards, dialogs |
+| Large | 16dp | FAB, navigation drawers |
+| Extra Large | 28dp | Large containers |
+| Full | 50% | Circles, pills |
+
+### Shape Family
+
+```kotlin
+// Define shapes
+val shapes = Shapes(
+    extraSmall = RoundedCornerShape(4.dp),
+    small = RoundedCornerShape(8.dp),
+    medium = RoundedCornerShape(12.dp),
+    large = RoundedCornerShape(16.dp),
+    extraLarge = RoundedCornerShape(28.dp)
+)
+```
+
+## Components
+
+### Buttons
+
+| Type | Container | Text | Use |
+|------|-----------|------|-----|
+| Filled | Primary | On Primary | Highest emphasis |
+| Filled Tonal | Secondary Container | On Secondary Container | Medium emphasis |
+| Outlined | None + outline | Primary | Low emphasis |
+| Text | None | Primary | Lowest emphasis |
+| Elevated | Surface + elevation | Primary | Needs shadow |
+
+```kotlin
+// Compose examples
+Button(onClick = {}) { Text("Filled") }
+FilledTonalButton(onClick = {}) { Text("Tonal") }
+OutlinedButton(onClick = {}) { Text("Outlined") }
+TextButton(onClick = {}) { Text("Text") }
+ElevatedButton(onClick = {}) { Text("Elevated") }
+```
+
+### FAB (Floating Action Button)
+
+```
+┌─────────────────────────────────┐
+│ Size    │ Diameter │ Icon Size │
+├─────────────────────────────────┤
+│ Small   │ 40dp     │ 24dp      │
+│ Regular │ 56dp     │ 24dp      │
+│ Large   │ 96dp     │ 36dp      │
+│ Extended│ 56dp h   │ 24dp      │
+└─────────────────────────────────┘
+```
+
+Position: Bottom right, 16dp from edges
+
+### Text Fields
+
+```
+┌──────────────────────────────────────────┐
+│  Filled (default)                        │
+│  ┌────────────────────────────────────┐  │
+│  │ Label                              │  │
+│  │ Input text                         │  │
+│  │ ─────────────────────────────────  │  │
+│  │ Supporting text                    │  │
+│  └────────────────────────────────────┘  │
+│                                          │
+│  Outlined                                │
+│  ┌────────────────────────────────────┐  │
+│  │ Label ─────────────────────────────│  │
+│  │ Input text                         │  │
+│  │ ─────────────────────────────────  │  │
+│  │ Supporting text                    │  │
+│  └────────────────────────────────────┘  │
+└──────────────────────────────────────────┘
+```
+
+### Cards
+
+| Type | Elevation | Use Case |
+|------|-----------|----------|
+| Elevated | Level 1 | Default, needs shadow |
+| Filled | Level 0 | On elevated surfaces |
+| Outlined | Level 0 | On same-color surfaces |
+
+### Chips
+
+| Type | Use Case |
+|------|----------|
+| Assist | Smart suggestions, shortcuts |
+| Filter | Filtering content |
+| Input | Tags, entered information |
+| Suggestion | Dynamic recommendations |
+
+## Navigation
+
+### Bottom Navigation
+
+```
+┌──────────────────────────────────────────┐
+│              Content                      │
+├──────────────────────────────────────────┤
+│   🏠        🔍        ❤️        👤      │
+│  Home    Search   Favorites  Profile     │
+└──────────────────────────────────────────┘
+Height: 80dp
+```
+
+- 3-5 destinations
+- Icon + label always visible
+- Active indicator pill around icon
+
+### Navigation Rail (Tablets)
+
+```
+┌─────┬───────────────────────────────────┐
+│ ≡   │                                   │
+│     │                                   │
+│ 🏠  │                                   │
+│Home │          Content                  │
+│     │                                   │
+│ 🔍  │                                   │
+│Srch │                                   │
+│     │                                   │
+│ ❤️  │                                   │
+│Favs │                                   │
+└─────┴───────────────────────────────────┘
+Width: 80dp
+```
+
+### Navigation Drawer
+
+```
+┌──────────────────────────┬──────────────┐
+│                          │              │
+│  App Name                │              │
+│  ─────────────────────   │              │
+│                          │              │
+│  🏠  Home                │    Content   │
+│  ●══════════════●        │              │
+│                          │              │
+│  📁  Files               │              │
+│  👥  Shared              │              │
+│  ⭐  Starred             │              │
+│                          │              │
+│  ─────────────────────   │              │
+│                          │              │
+│  ⚙️  Settings            │              │
+│                          │              │
+└──────────────────────────┴──────────────┘
+Width: 360dp max
+```
+
+### Top App Bar
+
+| Type | Scroll Behavior | Use Case |
+|------|-----------------|----------|
+| Small | Fixed or scroll | General use |
+| Medium | Scroll to collapse | With prominent titles |
+| Large | Scroll to collapse | Hero moments |
+| Center-aligned | Fixed | Simple apps |
+
+## Motion
+
+### Duration Scale
+
+| Token | Duration | Use Case |
+|-------|----------|----------|
+| Short 1 | 50ms | Simple selections |
+| Short 2 | 100ms | Icon changes |
+| Short 3 | 150ms | Snackbar entry |
+| Short 4 | 200ms | Dialogs, sheets |
+| Medium 1 | 250ms | Tabs, navigation |
+| Medium 2 | 300ms | Expanding components |
+| Medium 3 | 350ms | Navigation transitions |
+| Medium 4 | 400ms | Complex layouts |
+| Long 1 | 450ms | Page transitions |
+| Long 2 | 500ms | Large surface changes |
+| Long 3 | 550ms | View transitions |
+| Long 4 | 600ms | Reveal animations |
+| Extra Long | 700ms+ | Onboarding, tutorials |
+
+### Easing
+
+```kotlin
+// Standard easing
+val emphasized = CubicBezier(0.2f, 0f, 0f, 1f)
+val emphasizedDecelerate = CubicBezier(0.05f, 0.7f, 0.1f, 1f)
+val emphasizedAccelerate = CubicBezier(0.3f, 0f, 0.8f, 0.15f)
+
+// Linear (rarely used)
+val linear = CubicBezier(0f, 0f, 1f, 1f)
+```
+
+## 2025: Material 3 Expressive
+
+### New Features
+
+- **Springy Motion**: Physics-based animations
+- **Bolder Typography**: More expressive type choices
+- **Emotional Connection**: Design that makes users feel
+- **Personal Expression**: Beyond wallpaper colors
+
+### Recommendations
+
+```markdown
+✓ Use dynamic color for personalization
+✓ Add meaningful microinteractions
+✓ Consider emotional impact of choices
+✓ Balance expression with usability
+```
+
+## Accessibility
+
+### Touch Targets
+- Minimum: 48×48dp
+- Visual can be smaller, touch area must be 48dp
+
+### Contrast
+- Normal text: 4.5:1 minimum
+- Large text (18sp+): 3:1 minimum
+- UI components: 3:1 minimum
+
+### Focus
+- Visible focus indicator for all interactive elements
+- Logical focus order (left-to-right, top-to-bottom)
+
+### Screen Readers
+```kotlin
+Modifier.semantics {
+    contentDescription = "Add item to cart"
+    stateDescription = "Selected"
+}
+```
+
+## Layout
+
+### Grid System
+
+| Screen Size | Columns | Margins | Gutters |
+|-------------|---------|---------|---------|
+| < 600dp (Phone) | 4 | 16dp | 8dp |
+| 600-904dp (Tablet) | 8 | 32dp | 24dp |
+| ≥ 905dp (Desktop) | 12 | 32dp | 24dp |
+
+### Canonical Layouts
+
+```markdown
+## List-Detail
+For master-detail patterns on tablets
+├── List pane (1/3 width)
+└── Detail pane (2/3 width)
+
+## Supporting Panel
+For content with auxiliary info
+├── Main content (2/3 width)
+└── Side panel (1/3 width)
+
+## Feed
+For scrolling content
+└── Single column, card-based
+```
+
+## Resources
+
+- [Material Design 3](https://m3.material.io/)
+- [Material Theme Builder](https://m3.material.io/theme-builder)
+- [Material Components](https://github.com/material-components)

--- a/plugins/spellbook-ui/skills/app-ui-design/templates/design-system-template.md
+++ b/plugins/spellbook-ui/skills/app-ui-design/templates/design-system-template.md
@@ -1,0 +1,410 @@
+# Design System Template
+
+Use this template to define your app's design system.
+
+## App Information
+
+| Property | Value |
+|----------|-------|
+| App Name | [Your App Name] |
+| Platform | iOS / Android / Cross-platform |
+| Last Updated | [Date] |
+| Design Tool | Figma / Sketch / Adobe XD |
+
+---
+
+## Color Tokens
+
+### Primary Colors
+
+```css
+/* Primary */
+--color-primary: #[HEX];
+--color-primary-light: #[HEX];
+--color-primary-dark: #[HEX];
+--color-on-primary: #[HEX];
+
+/* Secondary */
+--color-secondary: #[HEX];
+--color-secondary-light: #[HEX];
+--color-secondary-dark: #[HEX];
+--color-on-secondary: #[HEX];
+
+/* Tertiary (Optional) */
+--color-tertiary: #[HEX];
+--color-on-tertiary: #[HEX];
+```
+
+### Background & Surface
+
+```css
+/* Light Mode */
+--color-background: #FFFFFF;
+--color-surface: #F5F5F5;
+--color-surface-variant: #E8E8E8;
+
+/* Dark Mode */
+--color-background-dark: #121212;
+--color-surface-dark: #1E1E1E;
+--color-surface-variant-dark: #2C2C2C;
+```
+
+### Text Colors
+
+```css
+/* Light Mode */
+--color-text-primary: #1A1A1A;
+--color-text-secondary: #666666;
+--color-text-disabled: #999999;
+--color-text-hint: #AAAAAA;
+
+/* Dark Mode */
+--color-text-primary-dark: #FFFFFF;
+--color-text-secondary-dark: #B3B3B3;
+--color-text-disabled-dark: #666666;
+```
+
+### Semantic Colors
+
+```css
+/* Status */
+--color-error: #D32F2F;
+--color-error-light: #FFEBEE;
+--color-on-error: #FFFFFF;
+
+--color-warning: #F9A825;
+--color-warning-light: #FFF8E1;
+--color-on-warning: #000000;
+
+--color-success: #388E3C;
+--color-success-light: #E8F5E9;
+--color-on-success: #FFFFFF;
+
+--color-info: #1976D2;
+--color-info-light: #E3F2FD;
+--color-on-info: #FFFFFF;
+```
+
+### Outline & Divider
+
+```css
+--color-outline: #E0E0E0;
+--color-outline-variant: #BDBDBD;
+--color-divider: #EEEEEE;
+```
+
+---
+
+## Typography
+
+### Font Families
+
+```css
+/* iOS */
+--font-family-primary: 'SF Pro Text', -apple-system, sans-serif;
+--font-family-display: 'SF Pro Display', -apple-system, sans-serif;
+
+/* Android */
+--font-family-primary: 'Roboto', sans-serif;
+--font-family-display: 'Roboto', sans-serif;
+
+/* Cross-platform alternative */
+--font-family-primary: 'Inter', system-ui, sans-serif;
+```
+
+### Type Scale
+
+| Token | Size | Weight | Line Height | Use |
+|-------|------|--------|-------------|-----|
+| display-large | 57px | 400 | 64px | Hero text |
+| display-medium | 45px | 400 | 52px | Large headers |
+| display-small | 36px | 400 | 44px | Section titles |
+| headline-large | 32px | 400 | 40px | Page titles |
+| headline-medium | 28px | 400 | 36px | Section headers |
+| headline-small | 24px | 400 | 32px | Card titles |
+| title-large | 22px | 500 | 28px | List item titles |
+| title-medium | 16px | 500 | 24px | Subtitles |
+| title-small | 14px | 500 | 20px | Captions |
+| body-large | 16px | 400 | 24px | Main body text |
+| body-medium | 14px | 400 | 20px | Secondary text |
+| body-small | 12px | 400 | 16px | Helper text |
+| label-large | 14px | 500 | 20px | Button text |
+| label-medium | 12px | 500 | 16px | Chips, badges |
+| label-small | 11px | 500 | 16px | Timestamps |
+
+### CSS Variables
+
+```css
+--font-size-display-large: 57px;
+--font-size-display-medium: 45px;
+--font-size-display-small: 36px;
+--font-size-headline-large: 32px;
+--font-size-headline-medium: 28px;
+--font-size-headline-small: 24px;
+--font-size-title-large: 22px;
+--font-size-title-medium: 16px;
+--font-size-title-small: 14px;
+--font-size-body-large: 16px;
+--font-size-body-medium: 14px;
+--font-size-body-small: 12px;
+--font-size-label-large: 14px;
+--font-size-label-medium: 12px;
+--font-size-label-small: 11px;
+```
+
+---
+
+## Spacing
+
+### Base Unit
+
+```css
+--spacing-unit: 8px;
+```
+
+### Spacing Scale
+
+```css
+--spacing-0: 0px;
+--spacing-1: 4px;   /* 0.5 units */
+--spacing-2: 8px;   /* 1 unit */
+--spacing-3: 12px;  /* 1.5 units */
+--spacing-4: 16px;  /* 2 units */
+--spacing-5: 20px;  /* 2.5 units */
+--spacing-6: 24px;  /* 3 units */
+--spacing-8: 32px;  /* 4 units */
+--spacing-10: 40px; /* 5 units */
+--spacing-12: 48px; /* 6 units */
+--spacing-16: 64px; /* 8 units */
+--spacing-20: 80px; /* 10 units */
+```
+
+### Layout Spacing
+
+```css
+/* Screen margins */
+--layout-margin-mobile: 16px;
+--layout-margin-tablet: 24px;
+--layout-margin-desktop: 32px;
+
+/* Content spacing */
+--layout-gutter: 16px;
+--layout-section-gap: 32px;
+--layout-card-gap: 16px;
+
+/* Component internal padding */
+--padding-button-horizontal: 24px;
+--padding-button-vertical: 12px;
+--padding-card: 16px;
+--padding-input: 12px;
+```
+
+---
+
+## Border Radius
+
+```css
+--radius-none: 0px;
+--radius-xs: 4px;
+--radius-sm: 8px;
+--radius-md: 12px;
+--radius-lg: 16px;
+--radius-xl: 24px;
+--radius-2xl: 32px;
+--radius-full: 9999px;
+```
+
+### Component Defaults
+
+```css
+--radius-button: 8px;
+--radius-button-pill: 9999px;
+--radius-card: 12px;
+--radius-input: 8px;
+--radius-dialog: 16px;
+--radius-fab: 16px;
+--radius-chip: 8px;
+--radius-avatar: 9999px;
+```
+
+---
+
+## Shadows & Elevation
+
+### Light Mode
+
+```css
+--shadow-1: 0 1px 2px rgba(0, 0, 0, 0.05);
+--shadow-2: 0 1px 3px rgba(0, 0, 0, 0.1), 0 1px 2px rgba(0, 0, 0, 0.06);
+--shadow-3: 0 4px 6px rgba(0, 0, 0, 0.1), 0 2px 4px rgba(0, 0, 0, 0.06);
+--shadow-4: 0 10px 15px rgba(0, 0, 0, 0.1), 0 4px 6px rgba(0, 0, 0, 0.05);
+--shadow-5: 0 20px 25px rgba(0, 0, 0, 0.1), 0 10px 10px rgba(0, 0, 0, 0.04);
+```
+
+### Dark Mode (Tonal Elevation)
+
+```css
+--elevation-1: linear-gradient(0deg, rgba(255,255,255,0.05), rgba(255,255,255,0.05));
+--elevation-2: linear-gradient(0deg, rgba(255,255,255,0.08), rgba(255,255,255,0.08));
+--elevation-3: linear-gradient(0deg, rgba(255,255,255,0.11), rgba(255,255,255,0.11));
+--elevation-4: linear-gradient(0deg, rgba(255,255,255,0.12), rgba(255,255,255,0.12));
+--elevation-5: linear-gradient(0deg, rgba(255,255,255,0.14), rgba(255,255,255,0.14));
+```
+
+### Component Elevation
+
+| Component | Level | Shadow |
+|-----------|-------|--------|
+| Flat elements | 0 | None |
+| Cards | 1 | shadow-1 |
+| Navigation | 2 | shadow-2 |
+| FAB | 3 | shadow-3 |
+| Dialogs | 4 | shadow-4 |
+| Modals | 5 | shadow-5 |
+
+---
+
+## Motion
+
+### Duration
+
+```css
+--duration-instant: 50ms;
+--duration-fast: 100ms;
+--duration-normal: 200ms;
+--duration-slow: 300ms;
+--duration-slower: 400ms;
+--duration-slowest: 500ms;
+```
+
+### Easing
+
+```css
+--easing-standard: cubic-bezier(0.4, 0.0, 0.2, 1);
+--easing-decelerate: cubic-bezier(0.0, 0.0, 0.2, 1);
+--easing-accelerate: cubic-bezier(0.4, 0.0, 1, 1);
+--easing-sharp: cubic-bezier(0.4, 0.0, 0.6, 1);
+--easing-spring: cubic-bezier(0.175, 0.885, 0.32, 1.275);
+```
+
+### Common Transitions
+
+```css
+--transition-color: color var(--duration-fast) var(--easing-standard);
+--transition-background: background-color var(--duration-fast) var(--easing-standard);
+--transition-transform: transform var(--duration-normal) var(--easing-standard);
+--transition-opacity: opacity var(--duration-normal) var(--easing-standard);
+--transition-all: all var(--duration-normal) var(--easing-standard);
+```
+
+---
+
+## Components
+
+### Buttons
+
+| Variant | Background | Text | Border |
+|---------|------------|------|--------|
+| Primary | --color-primary | --color-on-primary | None |
+| Secondary | --color-secondary | --color-on-secondary | None |
+| Outline | Transparent | --color-primary | --color-primary |
+| Ghost | Transparent | --color-primary | None |
+| Destructive | --color-error | --color-on-error | None |
+
+### States
+
+| State | Opacity | Additional |
+|-------|---------|------------|
+| Default | 100% | - |
+| Hover | - | +8% overlay |
+| Pressed | - | +12% overlay |
+| Focused | - | Focus ring |
+| Disabled | 50% | cursor: not-allowed |
+
+### Sizes
+
+| Size | Height | Padding | Font |
+|------|--------|---------|------|
+| Small | 32px | 12px 16px | label-medium |
+| Medium | 40px | 12px 24px | label-large |
+| Large | 48px | 14px 32px | label-large |
+
+---
+
+## Icons
+
+### Size Scale
+
+```css
+--icon-xs: 16px;
+--icon-sm: 20px;
+--icon-md: 24px;
+--icon-lg: 32px;
+--icon-xl: 48px;
+```
+
+### Icon Sets
+
+- iOS: SF Symbols
+- Android: Material Symbols
+- Cross-platform: [Your chosen set]
+
+---
+
+## Touch Targets
+
+```css
+/* Minimum sizes */
+--touch-target-min: 44px;  /* iOS */
+--touch-target-min-android: 48px;  /* Android */
+
+/* Recommended */
+--touch-target-recommended: 48px;
+
+/* Spacing between targets */
+--touch-target-gap: 8px;
+```
+
+---
+
+## Breakpoints
+
+```css
+--breakpoint-mobile: 0px;      /* 0-599 */
+--breakpoint-tablet: 600px;    /* 600-904 */
+--breakpoint-laptop: 905px;    /* 905-1239 */
+--breakpoint-desktop: 1240px;  /* 1240-1439 */
+--breakpoint-wide: 1440px;     /* 1440+ */
+```
+
+---
+
+## Z-Index Scale
+
+```css
+--z-base: 0;
+--z-dropdown: 100;
+--z-sticky: 200;
+--z-overlay: 300;
+--z-modal: 400;
+--z-popover: 500;
+--z-toast: 600;
+--z-tooltip: 700;
+```
+
+---
+
+## Checklist
+
+Before using this design system, verify:
+
+- [ ] All color tokens defined
+- [ ] Light and dark mode variants
+- [ ] Typography scale complete
+- [ ] Spacing scale consistent
+- [ ] All component states defined
+- [ ] Accessibility requirements met (contrast, touch targets)
+- [ ] Motion tokens defined
+- [ ] Breakpoints defined
+- [ ] Design tool file linked
+- [ ] Documentation complete

--- a/plugins/spellbook-ui/skills/figma-to-react/SKILL.md
+++ b/plugins/spellbook-ui/skills/figma-to-react/SKILL.md
@@ -1,0 +1,256 @@
+---
+name: figma-to-react
+description: Use when the user wants to extract Figma designs into production-ready React or Next.js components with TypeScript, Tailwind CSS, and pixel-perfect accuracy.
+---
+
+# Figma to React - Production-Ready Component Generator
+
+## 🎯 Purpose
+
+Extract **complete, lossless** design information from Figma and generate production-ready React/Next.js components with TypeScript and Tailwind CSS.
+
+---
+
+## 🚨 CRITICAL RULES - Read First!
+
+### **Rule 1: NEVER Truncate Code**
+
+Use **100% of Figma MCP output**. Every className, every property matters.
+
+```tsx
+// ✅ CORRECT: Keep ALL className from Figma MCP
+<div className="absolute font-source-serif h-[108px] leading-[1.8] left-[100px] not-italic text-[20px] text-[rgba(29,38,45,0.8)] text-justify top-[210px] w-[1096px] whitespace-pre-wrap">
+
+// ❌ WRONG: Removing any className
+<div className="absolute left-[100px] top-[210px] font-source-serif text-[20px]">
+```
+
+### **Rule 2: Flatten `absolute contents` Structures**
+
+**🔥 CRITICAL: Figma MCP returns nested `absolute contents` containers. `display: contents` makes the parent "disappear" - children are positioned relative to the nearest positioned ancestor (root)!**
+
+**Key Insight: Children's positions are ALREADY absolute - DO NOT add parent's top/left!**
+
+```tsx
+// ❌ WRONG: Figma MCP output (has redundant parent wrapper)
+<div className="absolute contents left-0 top-[41px]">
+  <p className="absolute left-[100px] top-[41px]">TITLE</p>
+  <div className="absolute left-0 top-[100px]">Line</div>
+</div>
+
+// ✅ CORRECT: Just remove the parent wrapper, keep children's positions AS-IS
+<>
+  <p className="absolute left-[100px] top-[41px]">TITLE</p>
+  <div className="absolute left-0 top-[100px] w-[1920px] h-[1px] bg-[#C5CBCE] opacity-30" />
+</>
+```
+
+**Position Handling Rules:**
+
+| Parent Type | Child Position | Action |
+|-------------|----------------|--------|
+| `absolute contents` | Child has own `top/left` | **Keep child position AS-IS**, just remove parent |
+| `absolute` (no contents) | Child has relative `top/left` | Calculate: `parent + child` |
+| `relative` | Child has `top/left` | Calculate: `parent + child` |
+
+**🔥 The Golden Rule:**
+```
+If parent has "contents" class → Child positions are already absolute → Keep AS-IS
+If parent has NO "contents" class → Child positions are relative → Add parent + child
+```
+
+**Reference: Verified correct positions (from production HTML):**
+- Header text: `top-[41px]` (not 82px)
+- Header line: `top-[100px]` (not 141px)
+- Footer line: `top-[980px]`
+- Page number: `top-[1004px]`
+
+### **Rule 3: Extract Dimensions from Metadata**
+
+**NEVER hardcode dimensions!**
+
+```typescript
+// 1. Get metadata first
+const metadata = await mcp__figma__get_metadata({
+  fileKey: 'xxx',
+  nodeId: '11:1420'
+})
+
+// 2. Extract from XML
+// <frame width="1920" height="1080">
+const pageWidth = 1920
+const pageHeight = 1080
+
+// 3. Use extracted values
+<div className="w-[1920px] h-[1080px]">
+```
+
+### **Rule 4: Font Loading & Name Mapping**
+
+**🔥 CRITICAL: Use Google Fonts CDN directly, NOT `next/font/google`!**
+
+`next/font/google` generates CSS variables and self-hosts fonts, but the font rendering may differ from reference HTML that uses Google Fonts CDN directly. This causes:
+- Different character widths (text wrapping issues)
+- Different optical size handling for variable fonts
+
+#### **4.1 Font Loading (layout.tsx)**
+
+```tsx
+// ❌ WRONG: Using next/font/google
+import { Source_Serif_4, Kaisei_Tokumin } from 'next/font/google'
+const sourceSerif = Source_Serif_4({ subsets: ['latin'], variable: '--font-source-serif' })
+// This may render fonts differently than Google Fonts CDN!
+
+// ✅ CORRECT: Use Google Fonts CDN directly in layout.tsx
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <head>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Source+Serif+4:ital,opsz,wght@0,8..60,200..900;1,8..60,200..900&family=Kaisei+Tokumin:wght@400;500;700;800&display=swap"
+          rel="stylesheet"
+        />
+      </head>
+      <body>{children}</body>
+    </html>
+  )
+}
+```
+
+**Key:** Include `opsz` (optical size) axis for Source Serif 4 - this affects character widths!
+
+#### **4.2 Font CSS (globals.css)**
+
+```css
+@layer utilities {
+  /* Use direct font-family names, NOT CSS variables */
+  .font-source-serif {
+    font-family: 'Source Serif 4', serif;
+  }
+  .font-kaisei {
+    font-family: 'Kaisei Tokumin', serif;
+  }
+}
+```
+
+#### **4.3 Font Name Mapping**
+
+```typescript
+// Figma MCP returns:
+font-['Kaisei_Tokumin:ExtraBold',sans-serif]
+font-['Source_Serif_Pro:SemiBold',sans-serif]
+
+// ✅ Convert to Tailwind classes:
+font-kaisei font-extrabold
+font-source-serif font-semibold
+
+// Font name corrections (Google Fonts 2024):
+'Source Serif Pro' → 'Source Serif 4'
+'Source Sans Pro' → 'Source Sans 3'
+```
+
+#### **4.4 Font Weight Mismatch Warning**
+
+**⚠️ Figma's font weight names may NOT match CSS font-weights!**
+
+Figma renders fonts differently than browsers. What Figma calls "Bold" might visually appear lighter than CSS `font-weight: 700`.
+
+| Figma Weight Name | Expected CSS | May Actually Need |
+|-------------------|--------------|-------------------|
+| Regular | 400 | 400 |
+| Medium | 500 | 500 |
+| Bold | 700 | **500 or 600** (test visually!) |
+| ExtraBold | 800 | **700** (test visually!) |
+
+**Solution:** Always compare with Figma screenshot. If text looks too bold, try one weight lighter:
+- `font-bold` (700) → try `font-medium` (500)
+- `font-extrabold` (800) → try `font-bold` (700)
+
+### **Rule 5: Critical CSS**
+
+**Must add to globals.css:**
+
+```css
+body {
+  overflow-x: auto; /* Allow horizontal scroll */
+}
+
+.page-container {
+  min-width: max-content;  /* Prevent compression */
+  display: inline-block;   /* Keep layout intact */
+}
+```
+
+### **Rule 6: Replace Simple Images with CSS**
+
+**Optimize line images:**
+
+```tsx
+// ❌ Before: Image-based line
+<div className="absolute h-0 left-0 top-[100px] w-[1920px]">
+  <div className="absolute inset-[-1px_0_0_0]">
+    <img src={imgLine} />
+  </div>
+</div>
+
+// ✅ After: CSS-based line
+<div className="absolute left-0 top-[141px] w-[1920px] h-[1px] bg-[#C5CBCE] opacity-30" />
+```
+
+### **Rule 7: Inline SVG Assets**
+
+```tsx
+// ❌ Before: External image
+<img src={imgVector} />
+
+// ✅ After: Inline SVG
+<svg viewBox="0 0 35 34" fill="none">
+  <path d="M17.5 0L0 34..." fill="#1d262d"/>
+</svg>
+```
+
+### **Rule 7.5: Remove Fixed Heights from Text Blocks**
+
+**🔥 CRITICAL: Figma MCP outputs fixed heights for text blocks, but this causes line-wrapping issues!**
+
+Font metrics differ between Figma's rendering and browser rendering (even with the same font family). Fixed heights can cause:
+- Text overflow or clipping
+- Different line counts than expected
+- Layout breaks when font rendering differs slightly
+
+```tsx
+// ❌ WRONG: Figma MCP output with fixed height
+<p className="absolute h-[72px] leading-[1.8] left-[100px] text-[20px] top-[570px] w-[1096px]">
+  Long text that might wrap differently in browser...
+</p>
+
+// ✅ CORRECT: Remove h-[Xpx], let text flow naturally
+<div className="absolute leading-[1.8] left-[100px] text-[20px] top-[570px] w-[1096px]">
+  <p className="mb-0">Long text that might wrap differently in browser...</p>
+</div>
+```
+
+**When to keep fixed heights:**
+- Container elements (cards, boxes) - keep dimensions
+- Table rows with single-line content - keep `h-[34px]`
+- Images and icons - keep dimensions
+
+**When to remove fixed heights:**
+- Multi-line text paragraphs - ALWAYS remove `h-[Xpx]`
+- Text blocks with `text-justify` - especially important
+- Any text that could wrap differently
+
+**Pattern: Use `<div>` wrapper with `<p className="mb-0">`:**
+```tsx
+// This matches reference HTML structure and ensures proper text flow
+<div className="absolute font-source-serif leading-[1.8] left-[100px] text-[20px] top-[570px] w-[1096px]">
+  <p className="mb-0">Text content here...</p>
+</div>
+```
+
+
+## Extended Reference
+
+Detailed material starting at `### **Rule 8: Table Pattern Detection & Conversion**` has been moved to [`reference/extended.md`](reference/extended.md) to keep this skill concise. Load that reference when the task requires the moved examples, command catalogs, checklists, platform details, or implementation templates.

--- a/plugins/spellbook-ui/skills/figma-to-react/reference/extended.md
+++ b/plugins/spellbook-ui/skills/figma-to-react/reference/extended.md
@@ -1,0 +1,710 @@
+# figma-to-react Extended Reference
+
+This file preserves detailed material moved out of `SKILL.md` for progressive disclosure. Load it only when the current task needs the specific examples, commands, templates, or checklists below.
+
+Moved content starts at: `### **Rule 8: Table Pattern Detection & Conversion**`.
+
+### **Rule 8: Table Pattern Detection & Conversion**
+
+**🔥 CRITICAL: Figma designs tables using absolute positioning, NOT HTML `<table>` elements!**
+
+#### **How to Detect Table Patterns**
+
+Look for these characteristics in Figma MCP output:
+
+```tsx
+// Table pattern indicators:
+// 1. Multiple rows with same height (e.g., h-[34px])
+// 2. Repeating left positions across rows (columns)
+// 3. Parent container with flex flex-col
+// 4. Background color alternation (header vs data rows)
+
+// Example Figma MCP output for a table:
+<div className="flex flex-col w-[1792px]">
+  {/* Header row - distinct background */}
+  <div className="bg-[#decfba] h-[34px] relative">
+    <p className="absolute left-[60px]">Label</p>
+    <p className="absolute left-[418px]">Jun-26</p>
+    <p className="absolute left-[669px]">Jun-26</p>
+    <p className="absolute left-[920px]">Jun-26</p>
+  </div>
+  {/* Data rows - same structure, different content */}
+  <div className="h-[34px] relative">
+    <p className="absolute left-[60px]">Row Label</p>
+    <p className="absolute left-[477px] -translate-x-full">$6,185,061</p>
+    <p className="absolute left-[728px] -translate-x-full">$6,185,061</p>
+  </div>
+</div>
+```
+
+#### **Detection Checklist**
+
+| Pattern | Indicator |
+|---------|-----------|
+| **Repeating structure** | Multiple divs with same `h-[Xpx]` |
+| **Column alignment** | Same `left-[Xpx]` values across rows |
+| **Header distinction** | First row has different `bg-[color]` |
+| **Right-aligned numbers** | Uses `left-[Xpx] -translate-x-full` |
+| **Container** | Parent has `flex flex-col` |
+
+#### **Conversion Options**
+
+**Option A: Follow Figma Exactly (RECOMMENDED)**
+
+Keep absolute positioning from Figma MCP. This ensures pixel-perfect accuracy.
+
+```tsx
+// ✅ RECOMMENDED: Use Figma's absolute positioning
+<div className="flex flex-col w-[1792px]">
+  {/* Header */}
+  <div className="bg-[#decfba] h-[34px] relative shrink-0">
+    <p className="absolute left-[60px] top-[7px]">Year Ending</p>
+    <p className="absolute left-[418px] top-[7px]">Jun-26</p>
+    <p className="absolute left-[669px] top-[7px]">Jun-26</p>
+    <p className="absolute left-[920px] top-[7px]">Jun-26</p>
+  </div>
+  {/* Data rows */}
+  <div className="h-[34px] relative shrink-0">
+    <p className="absolute left-[60px] top-[7px]">Revenue</p>
+    <p className="absolute left-[477px] top-[7px] -translate-x-full">$6,185,061</p>
+    <p className="absolute left-[728px] top-[7px] -translate-x-full">$6,185,061</p>
+  </div>
+</div>
+```
+
+**Option B: Convert to Semantic HTML Table (NOT RECOMMENDED)**
+
+Only use if semantic HTML is explicitly required (accessibility, SEO).
+
+⚠️ **Conversion Challenges:**
+- Must calculate column widths from Figma positions
+- HTML tables don't support Tailwind width on `<col>` (needs inline styles)
+- React hydration requires `<thead>` and `<tbody>` wrappers
+- `table-layout: fixed` required for precise column control
+- Right-aligned values need `text-right` class on cells
+
+```tsx
+// ⚠️ ONLY if semantic HTML required - complex and error-prone
+<table className="w-[1792px] table-fixed border-collapse">
+  <colgroup>
+    <col style={{ width: '358px' }} />  {/* 418 - 60 = 358 */}
+    <col style={{ width: '251px' }} />  {/* 669 - 418 = 251 */}
+    <col style={{ width: '251px' }} />  {/* 920 - 669 = 251 */}
+    {/* Calculate each column width from left positions */}
+  </colgroup>
+  <thead>
+    <tr className="bg-[#decfba] h-[34px]">
+      <th className="text-left pl-[60px]">Year Ending</th>
+      <th className="text-left">Jun-26</th>
+      <th className="text-left">Jun-26</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr className="h-[34px]">
+      <td className="pl-[60px]">Revenue</td>
+      <td className="text-right pr-[calc(251px-59px)]">$6,185,061</td>
+      <td className="text-right pr-[calc(251px-59px)]">$6,185,061</td>
+    </tr>
+  </tbody>
+</table>
+```
+
+#### **Column Width Calculation (for Option B)**
+
+```typescript
+// Given Figma left positions: [60, 418, 669, 920, 1173, 1391, 1619, 1792]
+// Calculate column widths:
+const positions = [60, 418, 669, 920, 1173, 1391, 1619, 1792]
+const widths = positions.slice(1).map((pos, i) => pos - positions[i])
+// Result: [358, 251, 251, 253, 218, 228, 173]
+```
+
+#### **Right-Alignment Pattern**
+
+Figma uses a clever pattern for right-aligned numbers:
+
+```tsx
+// Figma pattern: position at right edge, then translate left by 100%
+<p className="absolute left-[477px] -translate-x-full">$6,185,061</p>
+
+// This means: the RIGHT edge of text is at left-[477px]
+// The 477px is the column's right boundary (418 + 59 padding)
+
+// For HTML table conversion, use:
+<td className="text-right">$6,185,061</td>
+```
+
+#### **Why Option A is Better**
+
+| Aspect | Option A (Absolute) | Option B (Table) |
+|--------|---------------------|------------------|
+| Accuracy | Pixel-perfect | Approximation |
+| Complexity | Low | High |
+| Maintainability | Easy | Difficult |
+| Column widths | Automatic | Manual calculation |
+| Right alignment | Built-in | Extra CSS needed |
+| React hydration | No issues | Needs thead/tbody |
+
+**🔥 Golden Rule: When in doubt, follow Figma MCP output exactly!**
+
+#### **Creating Reusable Table Row Components**
+
+When implementing tables with Option A, create a reusable `TableRow` component to reduce code duplication:
+
+```tsx
+/**
+ * Table Component Documentation Template
+ *
+ * 🔥 Table Pattern: Uses Figma's absolute positioning (Rule 8 Option A)
+ *
+ * Column positions:
+ * - Label column: left-[60px]
+ * - Data headers: left-[418px], left-[669px], left-[920px], ...
+ * - Data values (right-aligned): left-[477px], left-[728px], left-[979px], ...
+ *   with -translate-x-full for right alignment
+ *
+ * Row types:
+ * - Header: bg-[#decfba] font-semibold
+ * - Section header: font-semibold (no bg)
+ * - Data: text-[rgba(29,38,45,0.8)]
+ * - Subtotal: bg-[#d7dee3] font-semibold
+ * - Total: bg-[#232b32] text-white font-semibold
+ */
+
+// Define row variants based on Figma design
+type RowVariant = 'header' | 'section' | 'data' | 'subtotal' | 'total'
+
+// Reusable TableRow component
+const TableRow = ({
+  label,
+  values,
+  variant = 'data',
+}: {
+  label: string
+  values?: string[]
+  variant?: RowVariant
+}) => {
+  // Background colors from Figma
+  const bgClass = {
+    header: 'bg-[#decfba]',
+    section: '',
+    data: '',
+    subtotal: 'bg-[#d7dee3]',
+    total: 'bg-[#232b32]',
+  }[variant]
+
+  // Text styles from Figma
+  const textClass = {
+    header: 'font-source-serif font-semibold text-[#1d262d]',
+    section: 'font-source-serif font-semibold text-[#1d262d]',
+    data: 'font-source-serif text-[rgba(29,38,45,0.8)]',
+    subtotal: 'font-source-serif font-semibold text-[#1d262d]',
+    total: 'font-source-serif font-semibold text-white',
+  }[variant]
+
+  // 🔥 CRITICAL: Extract these positions from Figma MCP output!
+  // Header positions (left-aligned column headers)
+  const headerPositions = [
+    'left-[418px]', 'left-[669px]', 'left-[920px]',
+    'left-[1173px]', 'left-[1391px]', 'left-[1619px]'
+  ]
+  // Data value positions (right-aligned with -translate-x-full)
+  const dataPositions = [
+    'left-[477px]', 'left-[728px]', 'left-[979px]',
+    'left-[1232px]', 'left-[1450px]', 'left-[1678px]'
+  ]
+
+  return (
+    <div className={`${bgClass} ${textClass} h-[34px] leading-[20px] relative shrink-0 text-[20px] w-[1792px]`}>
+      <p className="absolute left-[60px] top-[7px]">{label}</p>
+      {values?.map((value, i) => (
+        <p
+          key={i}
+          className={`absolute top-[7px] ${
+            variant === 'header'
+              ? headerPositions[i]
+              : `${dataPositions[i]} text-right -translate-x-full`
+          }`}
+        >
+          {value}
+        </p>
+      ))}
+    </div>
+  )
+}
+```
+
+#### **Complete Table Component Example**
+
+```tsx
+export default function FinancialTable() {
+  const headers = ['Jun-26', 'Jun-26', 'Jun-26', 'Jun-26', 'Jun-26', 'Jun-26']
+  const dataValues = ['$6,185,061', '$6,185,061', '$6,185,061', '$6,185,061', '$6,185,061', '$6,185,061']
+
+  return (
+    <div className="page-container">
+      <div className="bg-[#f8f7f5] relative w-[1920px] h-[1080px]">
+        {/* Tables Container - positions from Figma */}
+        <div className="absolute flex flex-col h-[728px] items-center left-[100px] top-[234px] w-[1720px]">
+          <div className="flex flex-col gap-[48px] items-start relative shrink-0">
+            {/* Table 1 */}
+            <div className="flex flex-col items-start relative shrink-0">
+              <TableRow label="Year Ending" values={headers} variant="header" />
+              <TableRow label="Revenue" variant="section" />
+              <TableRow label="Rental Income" values={dataValues} variant="data" />
+              <TableRow label="Other Income" values={dataValues} variant="data" />
+              <TableRow label="Total Revenue" values={dataValues} variant="subtotal" />
+              <TableRow label="Net Operating Income" values={dataValues} variant="total" />
+            </div>
+
+            {/* Table 2 - separated by gap-[48px] */}
+            <div className="flex flex-col items-start relative shrink-0">
+              <TableRow label="Year Ending" values={headers} variant="header" />
+              <TableRow label="Cash Flow" values={dataValues} variant="data" />
+              <TableRow label="Total" values={dataValues} variant="total" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+```
+
+#### **Key Patterns Summary**
+
+| Pattern | Implementation |
+|---------|----------------|
+| **Row height** | `h-[34px]` (extract from Figma) |
+| **Row width** | `w-[1792px]` (extract from Figma) |
+| **Label position** | `absolute left-[60px] top-[7px]` |
+| **Header values** | `absolute left-[Xpx] top-[7px]` (left-aligned) |
+| **Data values** | `absolute left-[Xpx] top-[7px] -translate-x-full` (right-aligned) |
+| **Multiple tables** | Wrap in `flex flex-col gap-[48px]` |
+| **Row variants** | Use object lookup for bg/text classes |
+
+#### **Position Extraction Workflow**
+
+```typescript
+// 1. From Figma MCP output, find repeating left-[Xpx] patterns
+// Header row example:
+<p className="absolute left-[418px] top-[7px]">Jun-26</p>
+<p className="absolute left-[669px] top-[7px]">Jun-26</p>
+// → headerPositions = ['left-[418px]', 'left-[669px]', ...]
+
+// 2. For data rows, find the translate-x-[-100%] pattern
+<p className="absolute left-[477px] ... translate-x-[-100%]">$6,185,061</p>
+<p className="absolute left-[728px] ... translate-x-[-100%]">$6,185,061</p>
+// → dataPositions = ['left-[477px]', 'left-[728px]', ...]
+
+// 3. Note: dataPositions are typically headerPositions + cell padding
+// e.g., 477 = 418 + 59 (right edge of column)
+```
+
+---
+
+## 📋 Complete Workflow
+
+### **Phase 1: Extract Figma Data**
+
+**🔥 CRITICAL: Save ALL MCP data to project directory for reuse!**
+
+#### **Step 0: Create MCP Cache Directory**
+
+All Figma MCP data must be saved to the project's `.figma-mcp/` directory:
+
+```
+project-root/
+├── .figma-mcp/
+│   ├── disclaimer/                 # Page name as folder (kebab-case)
+│   │   ├── metadata.xml            # get_metadata result
+│   │   ├── design-context.tsx      # get_design_context result (full code)
+│   │   ├── screenshot.png          # get_screenshot result (if available)
+│   │   └── info.json               # Node info (nodeId, name, dimensions, timestamp)
+│   ├── financing-summary/
+│   │   ├── metadata.xml
+│   │   ├── design-context.tsx
+│   │   └── info.json
+│   └── README.md                   # Index of all cached pages
+```
+
+**Folder naming convention:**
+- Use page name in kebab-case (e.g., `financing-summary`, `table-of-contents`)
+- Keep `info.json` containing the `nodeId` for reference
+- This makes the cache human-readable and easier to navigate
+
+**Why cache MCP data:**
+- Avoid repeated API calls (rate limits, latency)
+- Full data preservation - no truncation or loss
+- Easy debugging and reference
+- Reproducible builds
+
+#### **Step 1: Call Figma MCP Tools**
+
+```typescript
+// Call these in parallel
+const [metadata, designContext, screenshot] = await Promise.all([
+  mcp__figma__get_metadata({
+    fileKey: 'DqEDSJTN6hW7rSw0fy6gq9',
+    nodeId: '11-1420',
+    clientLanguages: 'typescript',
+    clientFrameworks: 'react,nextjs'
+  }),
+  mcp__figma__get_design_context({
+    fileKey: 'DqEDSJTN6hW7rSw0fy6gq9',
+    nodeId: '11-1420',
+    clientLanguages: 'typescript',
+    clientFrameworks: 'react,nextjs'
+  }),
+  mcp__figma__get_screenshot({
+    fileKey: 'DqEDSJTN6hW7rSw0fy6gq9',
+    nodeId: '11-1420',
+    clientLanguages: 'typescript',
+    clientFrameworks: 'react,nextjs'
+  })
+])
+
+// Step 2: IMMEDIATELY save to project directory
+// Save metadata.xml - contains positions, dimensions, node structure
+// Save design-context.tsx - contains full generated code with all className
+// Save info.json - contains node name, page dimensions, fetch timestamp
+```
+
+**Step 2: Extract Information**
+
+From **metadata**:
+```xml
+<frame id="11:1420" width="1920" height="1080">
+  <text id="11:1421" x="100" y="132" width="216" height="46" />
+</frame>
+```
+
+From **design_context**:
+```tsx
+<div className="bg-[#f8f7f5] relative size-full">
+  <p className="absolute font-kaisei font-extrabold ... text-[32px] ...">
+    DISCLAIMER
+  </p>
+  <div className="absolute contents left-0 top-[41px]">
+    {/* Nested structure - needs flattening */}
+  </div>
+</div>
+```
+
+---
+
+### **Phase 2: Transform Figma MCP Output**
+
+**Step 1: Flatten `absolute contents` Structures**
+
+Algorithm:
+```
+1. Find all elements with className="absolute contents"
+2. For each nested child:
+   a. KEEP child's top/left AS-IS (parent with "contents" doesn't affect positioning!)
+   b. Remove parent wrapper
+   c. Replace <img> with CSS/SVG
+```
+
+Example transformation:
+```tsx
+// Input: Figma MCP output
+<div className="absolute contents left-0 top-[41px]" data-node-id="11:1423">
+  <div className="absolute h-0 left-0 top-[100px] w-[1920px]" data-node-id="11:1424">
+    <div className="absolute inset-[-1px_0_0_0]">
+      <img src={imgLine2} />
+    </div>
+  </div>
+  <p className="absolute font-kaisei font-bold ... left-[100px] ... top-[41px]" data-node-id="11:1425">
+    159-161 WEST 54TH STREET
+  </p>
+  <div className="absolute h-[34px] left-[1785px] top-[42px] w-[35px]" data-node-id="11:1426">
+    <img src={imgVector} />
+  </div>
+</div>
+
+// Output: Flattened React code
+// 🔥 Parent has "contents" - children positions stay AS-IS!
+// Line: top-[100px] (NOT 141px!)
+// Text: top-[41px] (NOT 82px!)
+// Logo: top-[42px] (NOT 83px!)
+
+<>
+  {/* Horizontal line - Replace img with CSS */}
+  <div className="absolute left-0 top-[100px] w-[1920px] h-[1px] bg-[#C5CBCE] opacity-30" />
+
+  {/* Title */}
+  <p className="absolute font-kaisei font-bold leading-normal left-[100px] not-italic opacity-80 text-[#1d262d] text-[24px] top-[41px]">
+    159-161 WEST 54TH STREET
+  </p>
+
+  {/* Logo - Inline SVG */}
+  <svg viewBox="0 0 35 34" fill="none" className="absolute left-[1785px] top-[42px] w-[35px] h-[34px]">
+    <path d="M17.5 0L0 34C8.10511..." fill="#1d262d"/>
+  </svg>
+</>
+```
+
+**Step 2: Convert Font Names**
+
+```typescript
+const convertFigmaFont = (className: string) => {
+  return className
+    .replace(/font-\['Kaisei_Tokumin:Bold',sans-serif\]/g, 'font-kaisei font-bold')
+    .replace(/font-\['Kaisei_Tokumin:ExtraBold',sans-serif\]/g, 'font-kaisei font-extrabold')
+    .replace(/font-\['Source_Serif_Pro:Regular',sans-serif\]/g, 'font-source-serif')
+    .replace(/font-\['Source_Serif_Pro:SemiBold',sans-serif\]/g, 'font-source-serif font-semibold')
+}
+```
+
+**Step 3: Simplify Nested Flex Containers (Optional)**
+
+Remove redundant `flex flex-col` wrappers:
+
+```tsx
+// ❌ Figma MCP output (complex)
+<div className="absolute bg-[#f1efeb] flex flex-col p-[24px]">
+  <div className="flex flex-col">
+    <div className="h-[51px]">Row 1</div>
+    <div className="h-[51px]">Row 2</div>
+  </div>
+  <div className="h-[51px]">Row 3</div>
+</div>
+
+// ✅ Simplified (flat)
+<div className="absolute bg-[#f1efeb] p-[24px]">
+  <div className="h-[51px] relative w-full">Row 1</div>
+  <div className="h-[51px] relative w-full">Row 2</div>
+  <div className="h-[51px] relative w-full">Row 3</div>
+</div>
+```
+
+---
+
+### **Phase 3: Generate React Component**
+
+**Template:**
+
+```tsx
+export default function PageName() {
+  return (
+    <div className="page-container">
+      <div className="bg-[#f8f7f5] relative w-[1920px] h-[1080px]">
+        {/* Insert flattened, optimized code here */}
+
+        {/* All className preserved from Figma MCP */}
+        {/* All positions calculated correctly */}
+        {/* All fonts mapped */}
+        {/* All images optimized */}
+      </div>
+    </div>
+  )
+}
+```
+
+---
+
+### **Phase 4: Verify Against Screenshot**
+
+**Checklist:**
+- [ ] Page dimensions match (1920x1080)
+- [ ] All text visible and positioned correctly
+- [ ] Font sizes match Figma (text-[20px], text-[24px], text-[32px])
+- [ ] Colors match exactly
+- [ ] Spacing is pixel-perfect
+- [ ] No layout compression (page-container CSS working)
+
+**Compare with Figma screenshot side-by-side**
+
+---
+
+## 🎨 Font Configuration
+
+**app/layout.tsx:**
+
+```typescript
+import { Source_Serif_4, Kaisei_Tokumin, Inter } from 'next/font/google'
+
+const sourceSerif = Source_Serif_4({
+  subsets: ['latin'],
+  weight: ['200', '300', '400', '500', '600', '700', '800', '900'],
+  variable: '--font-source-serif',
+  display: 'swap',
+})
+
+const kaisei = Kaisei_Tokumin({
+  subsets: ['latin'],
+  weight: ['400', '500', '700', '800'],
+  variable: '--font-kaisei',
+  display: 'swap',
+})
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en" className={`${sourceSerif.variable} ${kaisei.variable}`}>
+      <body className="m-0 p-0 overflow-x-auto">{children}</body>
+    </html>
+  )
+}
+```
+
+**app/globals.css:**
+
+```css
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  body {
+    overflow-x: auto;
+  }
+}
+
+@layer utilities {
+  .font-source-serif {
+    font-family: var(--font-source-serif);
+  }
+  .font-kaisei {
+    font-family: var(--font-kaisei);
+  }
+  .page-container {
+    min-width: max-content;
+    display: inline-block;
+  }
+}
+```
+
+---
+
+## 📦 Font Mapping Reference
+
+```typescript
+const FONT_MAPPINGS = {
+  // Kaisei Tokumin
+  "font-['Kaisei_Tokumin',sans-serif]": "font-kaisei",
+  "font-['Kaisei_Tokumin:Bold',sans-serif]": "font-kaisei font-bold",
+  "font-['Kaisei_Tokumin:ExtraBold',sans-serif]": "font-kaisei font-extrabold",
+
+  // Source Serif Pro → Source Serif 4 (renamed 2024)
+  "font-['Source_Serif_Pro',sans-serif]": "font-source-serif",
+  "font-['Source_Serif_Pro:Regular',sans-serif]": "font-source-serif",
+  "font-['Source_Serif_Pro:SemiBold',sans-serif]": "font-source-serif font-semibold",
+
+  // Inter
+  "font-['Inter',sans-serif]": "font-inter",
+}
+```
+
+---
+
+## ⚠️ Common Mistakes
+
+1. ❌ **Adding parent+child positions when parent has "contents"** → Elements at wrong positions!
+   - 🔥 If parent has `absolute contents`, child positions are ALREADY absolute - keep AS-IS!
+2. ❌ **Not flattening `absolute contents`** → Wrapper causes issues
+3. ❌ **Removing className** → Spacing/sizing wrong
+4. ❌ **Hardcoding dimensions** → Not scalable
+5. ❌ **Missing `page-container` CSS** → Layout compressed
+6. ❌ **Wrong font names** → Fonts don't load
+7. ❌ **Not comparing with screenshot** → Visual bugs
+8. ❌ **Converting table-like layouts to HTML `<table>`** → Column alignment breaks!
+   - 🔥 Figma uses absolute positioning for tables - keep it that way!
+   - HTML table conversion requires manual column width calculation
+   - Right-aligned values use `left-[Xpx] -translate-x-full`, not `text-right`
+9. ❌ **Keeping fixed heights `h-[Xpx]` on multi-line text blocks** → Text wrapping issues!
+   - 🔥 Font metrics differ between Figma and browser - text may need more/fewer lines
+   - Remove `h-[72px]`, `h-[108px]` etc. from text paragraphs
+   - Keep only `top-[Xpx]` for positioning, let height be automatic
+10. ❌ **Using `next/font/google` instead of Google Fonts CDN** → Character width differences!
+    - 🔥 `next/font` may load fonts with different optical size settings
+    - Use Google Fonts CDN directly in `<head>` for exact match with reference HTML
+    - Include `opsz` axis for variable fonts: `Source+Serif+4:ital,opsz,wght@0,8..60,200..900`
+11. ❌ **Trusting Figma's font weight names** → Text appears too bold/light!
+    - 🔥 Figma "Bold" ≠ CSS `font-weight: 700` in visual appearance
+    - Always compare with Figma screenshot, not just weight names
+    - May need to use one weight lighter than Figma suggests
+12. ❌ **Using `grid-cols-N` with equal columns for tables** → Text overlap/truncation!
+    - 🔥 CSS Grid with equal columns (`grid-cols-4`) creates fixed-width columns
+    - Long text like "Mortgage Placement Fee" can overflow in narrow columns
+    - **Solution:** Use HTML `<table>` for auto-sizing columns, or specify custom column widths
+    - Example: Instead of `grid-cols-4`, use `grid-cols-[200px_150px_250px_200px]`
+
+13. ❌ **Flattening elements inside nested frames incorrectly** → Footnotes/elements at wrong position!
+    - 🔥 Elements inside nested frames (NOT `absolute contents`) have RELATIVE positions
+    - Must calculate: `parent frame top + child top` for absolute position
+    - **Example from Figma MCP:**
+      ```tsx
+      // Figma structure:
+      // - Frame 168 at top-[132px] (NOT contents!)
+      //   - Footnote at top-[772px] (relative to Frame 168)
+
+      // ❌ WRONG: Use child position directly
+      <p className="absolute top-[772px]">Footnote text</p>
+
+      // ✅ CORRECT: Calculate absolute position = 132 + 772 = 904px
+      <p className="absolute top-[904px]">Footnote text</p>
+      ```
+    - **Key distinction:**
+      - Parent has `absolute contents` → child positions already absolute → keep AS-IS
+      - Parent has `absolute` (no contents) → child positions relative → ADD parent + child
+    - **Real example (FINANCING SUMMARY page):**
+      - Frame 168 (11:1506): `top-[132px]`
+      - Footnote (11:1576): `top-[772px]` inside Frame 168
+      - Absolute position: 132 + 772 = **904px** (NOT 772px or 1006px!)
+      - Footer line: `top-[1011px]`
+      - Gap: 1011 - 904 - 29 = **78px** clearance ✓
+
+**Position Calculation Quick Check:**
+| Parent Class | Child Action |
+|-------------|--------------|
+| `absolute contents` | Keep position AS-IS |
+| `absolute` (no contents) | Add parent + child |
+
+---
+
+## 🎯 Success Criteria
+
+A successful conversion has:
+- ✅ Zero loss of design information
+- ✅ All elements positioned correctly
+- ✅ Fonts load and render correctly
+- ✅ Colors match exactly
+- ✅ Layout doesn't compress on any screen size
+- ✅ Code is clean and maintainable
+- ✅ Matches Figma screenshot pixel-perfectly
+
+---
+
+## 📝 Quick Reference
+
+**Workflow Summary:**
+1. Extract Figma data (metadata + design_context + screenshot)
+2. Flatten all `absolute contents` structures (remove wrapper, keep children)
+3. Handle positions correctly:
+   - Parent has "contents" → Keep child position AS-IS
+   - Parent has no "contents" → Calculate parent + child
+4. Convert font names
+5. Replace simple images with CSS
+6. Inline SVG assets
+7. Generate React component
+8. Verify against screenshot
+
+**Remember:**
+- 🔥 `absolute contents` parent = children positions already absolute!
+- 🔥 DO NOT add parent+child when parent has "contents"
+- 🔥 Preserve ALL className
+- 🔥 Add page-container CSS
+- 🔥 Compare with screenshot
+- 🔥 Table-like layouts: keep Figma's absolute positioning, don't convert to HTML `<table>`!
+- 🔥 Use Google Fonts CDN directly, NOT `next/font/google`!
+- 🔥 Remove fixed heights from multi-line text blocks!
+- 🔥 Figma font weights may need adjustment - compare visually!
+
+**Reference Positions (from verified HTML):**
+```
+Header text: top-[41px]
+Header line: top-[100px]
+Footer line: top-[980px]
+Page number: top-[1004px]
+```

--- a/plugins/spellbook-ui/skills/frontend-design/SKILL.md
+++ b/plugins/spellbook-ui/skills/frontend-design/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: frontend-design
+description: "Create distinctive, production-grade web frontend interfaces with high design quality. Use when the user explicitly asks to build or substantially redesign a web component, page, or application. Only applies when repository inspection confirms that the visual surface is a browser-rendered web UI. Do not use for native or GPU-rendered graphics, shaders, games, terminal UIs, or other non-web visual systems. Ignore incidental mentions and traces."
+license: Complete terms in LICENSE.txt
+---
+
+This skill guides creation of distinctive, production-grade frontend interfaces that avoid generic "AI slop" aesthetics. Implement real working code with exceptional attention to aesthetic details and creative choices.
+
+The user provides frontend requirements: a component, page, application, or interface to build. They may include context about the purpose, audience, or technical constraints.
+
+## Gotchas and Scope Gate
+
+Use this skill only when the implementation target is a web frontend. Before applying its aesthetics guidance, verify that the relevant code is HTML/CSS/JavaScript or a web UI framework.
+
+Stop using this skill if repository inspection shows that the visual surface is implemented by a native renderer, GPU shader, game engine, terminal UI, video pipeline, or another non-web graphics stack. Route that work to the relevant language, rendering, or visual-verification workflow instead. A request to make something look more polished does not establish web-frontend scope.
+
+Trigger regression cases live in `evals/triggers.jsonl`.
+
+## Design Thinking
+
+Before coding, understand the context and commit to a BOLD aesthetic direction:
+- **Purpose**: What problem does this interface solve? Who uses it?
+- **Tone**: Pick an extreme: brutally minimal, maximalist chaos, retro-futuristic, organic/natural, luxury/refined, playful/toy-like, editorial/magazine, brutalist/raw, art deco/geometric, soft/pastel, industrial/utilitarian, etc. There are so many flavors to choose from. Use these for inspiration but design one that is true to the aesthetic direction.
+- **Constraints**: Technical requirements (framework, performance, accessibility).
+- **Differentiation**: What makes this UNFORGETTABLE? What's the one thing someone will remember?
+
+**CRITICAL**: Choose a clear conceptual direction and execute it with precision. Bold maximalism and refined minimalism both work - the key is intentionality, not intensity.
+
+Then implement working code (HTML/CSS/JS, React, Vue, etc.) that is:
+- Production-grade and functional
+- Visually striking and memorable
+- Cohesive with a clear aesthetic point-of-view
+- Meticulously refined in every detail
+
+## Frontend Aesthetics Guidelines
+
+Focus on:
+- **Typography**: Choose fonts that are beautiful, unique, and interesting. Avoid generic fonts like Arial and Inter; opt instead for distinctive choices that elevate the frontend's aesthetics; unexpected, characterful font choices. Pair a distinctive display font with a refined body font.
+- **Color & Theme**: Commit to a cohesive aesthetic. Use CSS variables for consistency. Dominant colors with sharp accents outperform timid, evenly-distributed palettes.
+- **Motion**: Use animations for effects and micro-interactions. Prioritize CSS-only solutions for HTML. Use Motion library for React when available. Focus on high-impact moments: one well-orchestrated page load with staggered reveals (animation-delay) creates more delight than scattered micro-interactions. Use scroll-triggering and hover states that surprise.
+- **Spatial Composition**: Unexpected layouts. Asymmetry. Overlap. Diagonal flow. Grid-breaking elements. Generous negative space OR controlled density.
+- **Backgrounds & Visual Details**: Create atmosphere and depth rather than defaulting to solid colors. Add contextual effects and textures that match the overall aesthetic. Apply creative forms like gradient meshes, noise textures, geometric patterns, layered transparencies, dramatic shadows, decorative borders, custom cursors, and grain overlays.
+
+NEVER use generic AI-generated aesthetics like overused font families (Inter, Roboto, Arial, system fonts), cliched color schemes (particularly purple gradients on white backgrounds), predictable layouts and component patterns, and cookie-cutter design that lacks context-specific character.
+
+Interpret creatively and make unexpected choices that feel genuinely designed for the context. No design should be the same. Vary between light and dark themes, different fonts, different aesthetics. NEVER converge on common choices (Space Grotesk, for example) across generations.
+
+**IMPORTANT**: Match implementation complexity to the aesthetic vision. Maximalist designs need elaborate code with extensive animations and effects. Minimalist or refined designs need restraint, precision, and careful attention to spacing, typography, and subtle details. Elegance comes from executing the vision well.
+
+Remember: Claude is capable of extraordinary creative work. Don't hold back, show what can truly be created when thinking outside the box and committing fully to a distinctive vision.
+
+## Verification
+
+Before completion, check the implemented interface in the target runtime whenever possible. Verify layout, responsive behavior, text fit, contrast, interaction states, and that the result is a working UI rather than a static mockup. For local apps, use the available browser or screenshot workflow to inspect desktop and mobile viewports before claiming the frontend is done.

--- a/plugins/spellbook-ui/skills/frontend-design/evals/triggers.jsonl
+++ b/plugins/spellbook-ui/skills/frontend-design/evals/triggers.jsonl
@@ -1,0 +1,5 @@
+{"id":"web-dashboard-redesign","prompt":"Redesign this React analytics dashboard so it feels distinctive and production-ready.","expected_trigger":true,"observed_trigger":true}
+{"id":"web-landing-page","prompt":"Build a polished responsive landing page in HTML and CSS for this product.","expected_trigger":true,"observed_trigger":true}
+{"id":"metal-black-hole","prompt":"这个 Rust 项目的黑洞效果由 Metal shader 渲染，帮我把视觉效果做得更高级。","expected_trigger":false,"observed_trigger":false}
+{"id":"native-game-renderer","prompt":"Improve the lighting and particles in this native game renderer.","expected_trigger":false,"observed_trigger":false}
+{"id":"quoted-frontend-trace","prompt":"日志里写着 frontend-design/SKILL.md，解释这行日志。","expected_trigger":false,"observed_trigger":false}

--- a/plugins/spellbook-ui/skills/ui-design-system/SKILL.md
+++ b/plugins/spellbook-ui/skills/ui-design-system/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: ui-design-system
+description: Use when creating or maintaining UI design systems, design tokens, component documentation, responsive calculations, quality checks, or design-dev handoff materials.
+---
+
+# UI Design System Toolkit
+
+Professional toolkit for creating and maintaining scalable design systems.
+
+## Core Capabilities
+- Design token generation (colors, typography, spacing)
+- Component system architecture
+- Responsive design calculations
+- Accessibility compliance
+- Developer handoff documentation
+
+## Key Scripts
+
+### design_token_generator.py
+Generates complete design system tokens from brand colors.
+
+**Usage**: `python scripts/design_token_generator.py [brand_color] [style] [format]`
+- Styles: modern, classic, playful
+- Formats: json, css, scss
+
+**Features**:
+- Complete color palette generation
+- Modular typography scale
+- 8pt spacing grid system
+- Shadow and animation tokens
+- Responsive breakpoints
+- Multiple export formats
+
+## Verification
+
+Before reporting completion, validate generated tokens or handoff artifacts against the requested brand color, output format, accessibility constraints, and the target implementation surface. For script usage, run the command with representative input and inspect the emitted JSON/CSS/SCSS for valid syntax and preserved brand values.

--- a/plugins/spellbook-ui/skills/ui-design-system/scripts/design_token_generator.py
+++ b/plugins/spellbook-ui/skills/ui-design-system/scripts/design_token_generator.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Generate basic design system tokens from a brand color."""
+
+from __future__ import annotations
+
+import argparse
+import colorsys
+import json
+import re
+import sys
+
+
+STYLE_PRESETS = {
+    "modern": {
+        "font_body": "Inter, ui-sans-serif, system-ui, sans-serif",
+        "font_display": "Inter, ui-sans-serif, system-ui, sans-serif",
+        "radius": "8px",
+        "shadow": "0 12px 32px rgba(15, 23, 42, 0.12)",
+    },
+    "classic": {
+        "font_body": "Georgia, ui-serif, serif",
+        "font_display": "Georgia, ui-serif, serif",
+        "radius": "4px",
+        "shadow": "0 8px 24px rgba(30, 41, 59, 0.10)",
+    },
+    "playful": {
+        "font_body": "Nunito, ui-sans-serif, system-ui, sans-serif",
+        "font_display": "Nunito, ui-sans-serif, system-ui, sans-serif",
+        "radius": "16px",
+        "shadow": "0 16px 36px rgba(88, 28, 135, 0.16)",
+    },
+}
+
+
+def parse_hex_color(value: str) -> tuple[int, int, int]:
+    match = re.fullmatch(r"#?([0-9a-fA-F]{6})", value.strip())
+    if not match:
+        raise ValueError("brand_color must be a 6-digit hex color, for example #2563eb")
+    raw = match.group(1)
+    return int(raw[0:2], 16), int(raw[2:4], 16), int(raw[4:6], 16)
+
+
+def to_hex(rgb: tuple[float, float, float]) -> str:
+    return "#" + "".join(f"{max(0, min(255, round(channel * 255))):02x}" for channel in rgb)
+
+
+def color_scale(brand_rgb: tuple[int, int, int]) -> dict[str, str]:
+    hue, _, saturation = colorsys.rgb_to_hls(*(channel / 255 for channel in brand_rgb))
+    scale_saturation = 0.0 if saturation < 0.02 else min(0.95, saturation)
+    brand_hex = "#" + "".join(f"{channel:02x}" for channel in brand_rgb)
+    stops = {
+        "50": 0.97,
+        "100": 0.92,
+        "200": 0.84,
+        "300": 0.74,
+        "400": 0.64,
+        "500": 0.52,
+        "600": 0.44,
+        "700": 0.34,
+        "800": 0.24,
+        "900": 0.16,
+    }
+    scale = {
+        key: to_hex(colorsys.hls_to_rgb(hue, lightness, scale_saturation))
+        for key, lightness in stops.items()
+    }
+    scale["500"] = brand_hex
+    return scale
+
+
+def build_tokens(brand_color: str, style: str) -> dict[str, object]:
+    preset = STYLE_PRESETS[style]
+    colors = color_scale(parse_hex_color(brand_color))
+    return {
+        "color": {
+            "brand": colors,
+            "semantic": {
+                "background": "#ffffff",
+                "foreground": "#111827",
+                "muted": "#f3f4f6",
+                "border": "#d1d5db",
+                "success": "#16a34a",
+                "warning": "#d97706",
+                "danger": "#dc2626",
+            },
+        },
+        "typography": {
+            "fontFamily": {
+                "body": preset["font_body"],
+                "display": preset["font_display"],
+            },
+            "fontSize": {
+                "xs": "0.75rem",
+                "sm": "0.875rem",
+                "base": "1rem",
+                "lg": "1.125rem",
+                "xl": "1.25rem",
+                "2xl": "1.5rem",
+                "3xl": "1.875rem",
+            },
+        },
+        "space": {str(step): f"{step * 0.5}rem" for step in range(0, 13)},
+        "radius": {
+            "sm": "4px",
+            "md": preset["radius"],
+            "lg": "calc(" + preset["radius"] + " * 1.5)",
+        },
+        "shadow": {
+            "sm": "0 1px 2px rgba(15, 23, 42, 0.08)",
+            "md": preset["shadow"],
+        },
+        "animation": {
+            "duration": {
+                "instant": "0ms",
+                "fast": "150ms",
+                "normal": "250ms",
+                "slow": "400ms",
+            },
+            "easing": {
+                "standard": "cubic-bezier(0.2, 0, 0, 1)",
+                "enter": "cubic-bezier(0, 0, 0.2, 1)",
+                "exit": "cubic-bezier(0.4, 0, 1, 1)",
+            },
+        },
+        "breakpoint": {
+            "sm": "640px",
+            "md": "768px",
+            "lg": "1024px",
+            "xl": "1280px",
+        },
+    }
+
+
+def flatten(prefix: str, value: object) -> dict[str, str]:
+    if isinstance(value, dict):
+        output: dict[str, str] = {}
+        for key, nested in value.items():
+            output.update(flatten(f"{prefix}-{key}" if prefix else str(key), nested))
+        return output
+    return {prefix: str(value)}
+
+
+def render_css(tokens: dict[str, object], scss: bool = False) -> str:
+    flat = flatten("", tokens)
+    if scss:
+        return "\n".join(f"${key}: {value};" for key, value in flat.items())
+    lines = [":root {"]
+    lines.extend(f"  --{key}: {value};" for key, value in flat.items())
+    lines.append("}")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("brand_color", help="6-digit hex color, for example #2563eb")
+    parser.add_argument("style", choices=sorted(STYLE_PRESETS), help="Visual style preset")
+    parser.add_argument("format", choices=["json", "css", "scss"], help="Output format")
+    args = parser.parse_args()
+
+    try:
+        tokens = build_tokens(args.brand_color, args.style)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    if args.format == "json":
+        print(json.dumps(tokens, indent=2))
+    elif args.format == "scss":
+        print(render_css(tokens, scss=True))
+    else:
+        print(render_css(tokens))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- add a `spellbook-ui` Codex plugin manifest generated with the supported plugin creator
- bundle exactly `frontend-design`, `app-ui-design`, `ui-design-system`, and `figma-to-react`
- include every companion reference, template, script, and eval used by those four catalog skills
- document local validation and a temporary local-marketplace pilot
- keep direct `npx skills add` installation as the public distribution path

## Boundaries

- no repository marketplace entry
- no apps, MCP servers, hooks, agents, or authentication claims
- no public marketplace claim
- no new synchronization subsystem; byte-for-byte directory comparison was used for this PR because the repository has no existing plugin-copy drift validator

## Verification

- official local plugin validator — passed
- exact top-level plugin skill directories — 4
- `diff -qr` against all four canonical catalog directories — no differences
- temporary marketplace scaffold + source sync + plugin validation + marketplace-name read — passed
- `python3 scripts/validate_skills.py --check` — 106 skills, 0 errors, 1 pre-existing advisory warning
- `PYTHONDONTWRITEBYTECODE=1 .../.venv/bin/python -m pytest -q` — 505 passed, 136 subtests passed
- packaged Python companion `py_compile` — passed
- Patch Guard — 16 expected files, 0 violations

Closes #187