### PR TITLE
fix(sol-luna-router): keep timeout usage in the run ledger

### DIFF
--- a/skills/sol-luna-router/SKILL.md
+++ b/skills/sol-luna-router/SKILL.md
@@ -190,7 +190,7 @@ ambiguous files remain visible as unresolved coverage. Resolved partial commande
 be shown, but commander-plus-worker totals and total-scope normalized metrics are null until every
 required parent window resolves. A complete total additionally requires every ledger run to have
 valid worker usage; commander-window coverage alone is insufficient. The runner preserves exact
-usage on failed Codex exits or failed turns when Codex emitted it, but absent usage remains
+usage on failed Codex exits, failed turns, or timeouts when Codex emitted it, but absent usage remains
 unresolved. The normalized credit metrics are observational cost-per-outcome measures; controlled
 A/B remains the causal total-cost proof.
 
@@ -217,7 +217,7 @@ has materially changed.
 
 - If the runner reports an incompatible or unavailable model, stop and report the exact error.
 - If Luna requests broader ownership, network, or permissions, return it to the user or revise the plan; do not grant it silently.
-- On timeout, retain the partial `thread_id` and events path; resume with a smaller prompt, or treat a run without a thread ID as unrecoverable.
+- On timeout, retain the partial `thread_id`, events path, and any emitted `usage`; resume with a smaller prompt, or treat a run without a thread ID as unrecoverable.
 - Treat `capacity_exhausted` as infrastructure capacity, not task quality; never lower Luna effort automatically.
 - Treat malformed JSONL, nonzero exit, `turn.failed`, missing completion, or missing final response as failure; recovered transport errors remain warnings.
 - Do not claim the Skill is effective from invocation count, worker success, or token totals alone;

--- a/skills/sol-luna-router/references/run-log.md
+++ b/skills/sol-luna-router/references/run-log.md
@@ -41,12 +41,12 @@ delete them according to the user's retention policy.
 ## Fields and interpretation
 
 `status` is `success` or `failed`. Run records include the exact normalized token fields emitted by
-Codex under `usage` when available, including on a failed exit or failed turn; absent usage is not
+Codex under `usage` when available, including on a failed exit, failed turn, or timeout; absent usage is not
 written as zero. The runner does not estimate billing or infer prices. Failures include a stable
 `failure_code` and exclude raw error messages. Important codes include:
 
 - `capacity_exhausted`: rate, quota, usage, credit, or spend capacity prevented completion;
-- `timeout`: the bounded worker runtime expired;
+- `timeout`: the bounded worker runtime expired; keep emitted usage when the partial stream has it;
 - `codex_exit` or `turn_failed`: Codex terminated unsuccessfully;
 - `invalid_jsonl`, `incomplete_turn`, `missing_thread_id`, `missing_final_response`;
 - `invalid_input`, `invalid_profile`, `non_git_target`, and `artifact_exists`.

--- a/skills/sol-luna-router/scripts/run_luna_worker.py
+++ b/skills/sol-luna-router/scripts/run_luna_worker.py
@@ -19,6 +19,11 @@ import time
 from typing import TextIO
 import uuid
 
+_SCRIPT_DIR = Path(__file__).resolve().parent
+if str(_SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPT_DIR))
+from worker_events import extract_error, normalize_usage, partial_event_summary
+
 
 MODEL = "gpt-5.6-luna"
 REASONING_EFFORT = "max"
@@ -31,7 +36,7 @@ OUTCOMES = ("verified", "needs_correction", "blocked", "rejected")
 RUN_LOG_ENV = "SOL_LUNA_RUN_LOG"
 PARENT_SESSION_ENV = "SOL_LUNA_PARENT_SESSION_ID"
 TELEMETRY_SCHEMA_VERSION = 1
-RUNNER_VERSION = "2.0.0"
+RUNNER_VERSION = "2.0.1"
 BOUNDED_REVIEW_POLICY = """Worker execution policy for bounded review:
 - Keep the target repository read-only. Use environment-owned temporary scratch only when required.
 - Use at most 8 repository commands and do not start a command expected to exceed 120 seconds.
@@ -350,23 +355,6 @@ def _terminate_process(process: subprocess.Popen[str]) -> None:
         process.wait()
 
 
-def partial_event_summary(stdout: str) -> tuple[str | None, int]:
-    thread_id: str | None = None
-    event_count = 0
-    for raw_line in stdout.splitlines():
-        try:
-            event = json.loads(raw_line)
-        except json.JSONDecodeError:
-            continue
-        if not isinstance(event, dict):
-            continue
-        event_count += 1
-        candidate = event.get("thread_id") if event.get("type") == "thread.started" else None
-        if isinstance(candidate, str) and candidate:
-            thread_id = candidate
-    return thread_id, event_count
-
-
 def build_worker_environment(profile: str, cache_root: Path | None) -> dict[str, str] | None:
     if profile != "bounded-review":
         return None
@@ -426,23 +414,26 @@ def execute_worker(
                 _terminate_process(process)
                 stdout = _read_stream(stdout_stream)
                 stderr = _read_stream(stderr_stream)
-                thread_id, event_count = partial_event_summary(stdout)
+                thread_id, event_count, usage = partial_event_summary(stdout)
                 recovery = (
                     f"resume with --thread-id {thread_id}"
                     if thread_id
                     else "no thread ID was observed"
                 )
                 artifact = str(events_path) if events_path else "not retained"
+                details: dict[str, object] = {
+                    "worker_thread_id": thread_id,
+                    "event_count": event_count,
+                    "duration_seconds": round(time.monotonic() - started_at, 3),
+                }
+                if usage:
+                    details["usage"] = usage
                 raise WorkerRunError(
                     f"Luna worker timed out after {timeout_seconds} seconds; {recovery}; "
                     f"partial events={event_count}; events_file={artifact}; "
                     f"stderr tail: {stderr[-STDERR_TAIL_CHARS:]}",
                     code="timeout",
-                    details={
-                        "worker_thread_id": thread_id,
-                        "event_count": event_count,
-                        "duration_seconds": round(time.monotonic() - started_at, 3),
-                    },
+                    details=details,
                 )
             if next_heartbeat is not None and now >= next_heartbeat:
                 print(
@@ -477,14 +468,17 @@ def parse_events(stdout: str, stderr: str, returncode: int) -> dict[str, object]
         try:
             event = json.loads(raw_line)
         except json.JSONDecodeError as error:
-            partial_thread_id, event_count = partial_event_summary(stdout)
+            partial_thread_id, event_count, partial_usage = partial_event_summary(stdout)
+            details = {
+                "worker_thread_id": partial_thread_id,
+                "event_count": event_count,
+            }
+            if partial_usage:
+                details["usage"] = partial_usage
             raise WorkerRunError(
                 f"Codex emitted invalid JSONL on line {line_number}: {error.msg}",
                 code="invalid_jsonl",
-                details={
-                    "worker_thread_id": partial_thread_id,
-                    "event_count": event_count,
-                },
+                details=details,
             ) from error
         if not isinstance(event, dict):
             raise WorkerRunError(
@@ -560,31 +554,6 @@ def parse_events(stdout: str, stderr: str, returncode: int) -> dict[str, object]
         "usage": usage,
         "event_count": len(events),
         "warnings": warnings,
-    }
-
-
-def extract_error(event: dict[str, object]) -> str:
-    error = event.get("error")
-    if isinstance(error, dict):
-        message = error.get("message")
-        if isinstance(message, str):
-            return message
-        return json.dumps(error, ensure_ascii=False, sort_keys=True)
-    if isinstance(error, str):
-        return error
-    message = event.get("message")
-    if isinstance(message, str):
-        return message
-    return json.dumps(event, ensure_ascii=False, sort_keys=True)
-
-
-def normalize_usage(usage: object) -> dict[str, int]:
-    if not isinstance(usage, dict):
-        return {}
-    return {
-        str(key): value
-        for key, value in usage.items()
-        if isinstance(value, int) and not isinstance(value, bool) and value >= 0
     }
 
 

--- a/skills/sol-luna-router/scripts/test_run_luna_worker.py
+++ b/skills/sol-luna-router/scripts/test_run_luna_worker.py
@@ -71,6 +71,9 @@ if mode == "post-start-unknown-field":
     raise SystemExit(7)
 if mode == "sleep":
     time.sleep(10)
+if mode == "sleep-with-usage":
+    print(json.dumps({"type": "item.completed", "usage": {"input_tokens": 21, "cached_input_tokens": 8, "output_tokens": 3}}), flush=True)
+    time.sleep(10)
 if mode == "recovered":
     print(json.dumps({"type": "error", "message": "Reconnecting after request timed out"}))
     print(json.dumps({"type": "item.completed", "item": {"type": "error", "message": "Falling back to HTTPS transport"}}))
@@ -594,6 +597,33 @@ class RunnerTests(unittest.TestCase):
         record = self.read_records()[0]
         self.assertEqual(record["failure_code"], "timeout")
         self.assertEqual(record["worker_thread_id"], "thread-123")
+        self.assertNotIn("usage", record)
+
+    def test_timeout_preserves_exact_usage_from_partial_stream(self) -> None:
+        events_file = self.root / "events" / "partial-usage.jsonl"
+        result = self.invoke(
+            "run",
+            "--cwd",
+            str(self.repo),
+            "--prompt-file",
+            str(self.prompt),
+            "--events-file",
+            str(events_file),
+            "--timeout-seconds",
+            "1",
+            "--heartbeat-seconds",
+            "0",
+            mode="sleep-with-usage",
+        )
+        self.assertEqual(result.returncode, 1)
+        record = self.read_records()[0]
+        self.assertEqual(record["failure_code"], "timeout")
+        self.assertEqual(record["worker_thread_id"], "thread-123")
+        self.assertEqual(record["event_count"], 2)
+        self.assertEqual(
+            record["usage"],
+            {"input_tokens": 21, "cached_input_tokens": 8, "output_tokens": 3},
+        )
 
     def test_existing_events_file_is_not_overwritten(self) -> None:
         events_file = self.root / "events.jsonl"
@@ -610,6 +640,34 @@ class RunnerTests(unittest.TestCase):
         self.assertEqual(result.returncode, 1)
         self.assertIn("already exists", result.stderr)
         self.assertEqual(events_file.read_text(encoding="utf-8"), "preserve\n")
+
+
+class WorkerEventTests(unittest.TestCase):
+    def test_partial_event_summary_keeps_last_usage(self) -> None:
+        from worker_events import partial_event_summary
+
+        stdout = "\n".join(
+            [
+                json.dumps({"type": "thread.started", "thread_id": "t1"}),
+                json.dumps({"type": "item.completed", "usage": {"input_tokens": 4}}),
+                json.dumps({"type": "item.completed", "usage": {"input_tokens": 9, "output_tokens": 2}}),
+                "not-json",
+            ]
+        )
+        thread_id, event_count, usage = partial_event_summary(stdout)
+        self.assertEqual(thread_id, "t1")
+        self.assertEqual(event_count, 3)
+        self.assertEqual(usage, {"input_tokens": 9, "output_tokens": 2})
+
+    def test_partial_event_summary_omits_empty_usage(self) -> None:
+        from worker_events import partial_event_summary
+
+        thread_id, event_count, usage = partial_event_summary(
+            json.dumps({"type": "thread.started", "thread_id": "t1"})
+        )
+        self.assertEqual(thread_id, "t1")
+        self.assertEqual(event_count, 1)
+        self.assertEqual(usage, {})
 
 
 if __name__ == "__main__":

--- a/skills/sol-luna-router/scripts/worker_events.py
+++ b/skills/sol-luna-router/scripts/worker_events.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Parse Codex JSONL worker events without storing prompt or answer text."""
+
+from __future__ import annotations
+
+import json
+
+
+def normalize_usage(usage: object) -> dict[str, int]:
+    if not isinstance(usage, dict):
+        return {}
+    return {
+        str(key): value
+        for key, value in usage.items()
+        if isinstance(value, int) and not isinstance(value, bool) and value >= 0
+    }
+
+
+def extract_error(event: dict[str, object]) -> str:
+    error = event.get("error")
+    if isinstance(error, dict):
+        message = error.get("message")
+        if isinstance(message, str):
+            return message
+        return json.dumps(error, ensure_ascii=False, sort_keys=True)
+    if isinstance(error, str):
+        return error
+    message = event.get("message")
+    if isinstance(message, str):
+        return message
+    return json.dumps(event, ensure_ascii=False, sort_keys=True)
+
+
+def partial_event_summary(stdout: str) -> tuple[str | None, int, dict[str, int]]:
+    thread_id: str | None = None
+    event_count = 0
+    usage: dict[str, int] = {}
+    for raw_line in stdout.splitlines():
+        try:
+            event = json.loads(raw_line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(event, dict):
+            continue
+        event_count += 1
+        candidate = event.get("thread_id") if event.get("type") == "thread.started" else None
+        if isinstance(candidate, str) and candidate:
+            thread_id = candidate
+        normalized = normalize_usage(event.get("usage"))
+        if normalized:
+            usage = normalized
+    return thread_id, event_count, usage


### PR DESCRIPTION
## What

Timeout records now keep exact worker `usage` when the partial Codex JSONL stream already emitted it.

Fixes #191

## Why

Local ledger evidence: 6/6 timeouts had a thread and 103–421 events, but none stored `usage`. That made worker cost coverage 68% and blocked commander-plus-worker totals. Missing usage stays absent; it is not written as zero.

## Changes

- Parse last integer `usage` from the partial stream on timeout and invalid JSONL
- Move event helpers into `worker_events.py` so `run_luna_worker.py` does not grow
- Cover timeout-with-usage, timeout-without-usage, and helper parsing
- Align `SKILL.md` / `run-log.md` with the same contract

## Test Plan

- [x] `python3 skills/sol-luna-router/scripts/test_run_luna_worker.py` (27 passed)
- [x] `python3 skills/sol-luna-router/scripts/test_analyze_run_log.py` (19 passed)
- [x] `python3 scripts/validate_skills.py --check`
- [x] `python3 scripts/audit_skill_quality.py sol-luna-router`
- [x] `bash -n install.sh`
- [ ] Tested manually against a live nested Codex timeout