### PR TITLE
fix(build-product-demo): allowlist ffmpeg noise CLI values (SEC-07)

### DIFF
--- a/skills/build-product-demo/scripts/analyze_demo_pacing.py
+++ b/skills/build-product-demo/scripts/analyze_demo_pacing.py
@@ -19,18 +19,33 @@ SILENCE_DURATION_RE = re.compile(r"silence_duration:\s*([0-9.]+)")
 FREEZE_START_RE = re.compile(r"freeze_start:\s*([0-9.]+)")
 FREEZE_END_RE = re.compile(r"freeze_end:\s*([0-9.]+)")
 FREEZE_DURATION_RE = re.compile(r"freeze_duration:\s*([0-9.]+)")
+NOISE_LEVEL_RE = re.compile(r"^-?[0-9]+(\.[0-9]+)?dB$")
+
+
+def validate_noise_level(value: str) -> str:
+    """Accept only strict ffmpeg dB noise levels for filtergraph interpolation.
+
+    Values are interpolated into -af/-vf filtergraphs. Reject anything that is
+    not an allowlisted dB literal so filtergraph metacharacters cannot inject
+    additional nodes (for example `,`, `;`, `[`, `]`, `:`, `=`).
+    """
+    if not isinstance(value, str) or not NOISE_LEVEL_RE.fullmatch(value):
+        raise argparse.ArgumentTypeError(
+            f"invalid noise level {value!r}; expected form like -35dB or 12.5dB"
+        )
+    return value
 
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("media", type=Path)
     parser.add_argument("--plan", type=Path, help="Validated beat plan containing hold intervals.")
-    parser.add_argument("--silence-noise", default="-35dB")
+    parser.add_argument("--silence-noise", type=validate_noise_level, default="-35dB")
     parser.add_argument("--silence-min-duration", type=float, default=0.45)
     # Terminal and code demos often change only a small text region. A more
     # sensitive default keeps those real interactions from being mistaken for
     # a frozen full-screen slide while still catching long static holds.
-    parser.add_argument("--freeze-noise", default="-50dB")
+    parser.add_argument("--freeze-noise", type=validate_noise_level, default="-50dB")
     parser.add_argument("--freeze-min-duration", type=float, default=1.0)
     parser.add_argument("--max-silence-ratio", type=float, default=0.18)
     parser.add_argument("--max-silence-segment", type=float, default=1.75)
@@ -165,6 +180,14 @@ def paths_alias(first: Path, second: Path) -> bool:
 
 def main() -> int:
     args = parse_args()
+    try:
+        # Re-validate before filter construction so Namespace/test paths cannot
+        # bypass argparse typing and inject filtergraph metacharacters.
+        args.silence_noise = validate_noise_level(args.silence_noise)
+        args.freeze_noise = validate_noise_level(args.freeze_noise)
+    except (argparse.ArgumentTypeError, TypeError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
     if not args.media.is_file():
         print(f"error: media not found: {args.media}", file=sys.stderr)
         return 2

--- a/tests/test_build_product_demo.py
+++ b/tests/test_build_product_demo.py
@@ -1065,3 +1065,113 @@ def test_open_ended_low_motion_segment_extends_to_media_end() -> None:
     )
 
     assert segments == [(1.5, 10.0, 8.5)]
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["-35dB", "-50dB", "0dB", "12.5dB", "-12.5dB"],
+)
+def test_validate_noise_level_accepts_allowlisted_db(value: str) -> None:
+    assert PACING.validate_noise_level(value) == value
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "x[out];nullsink",
+        "-35dB,anull",
+        "-35dB;nullsink",
+        "-35dB[out]",
+        "-35dB:d=1",
+        "-35dB=evil",
+        "35db",
+        "-35",
+        "",
+        " -35dB",
+        "-35dB ",
+        "--35dB",
+    ],
+)
+def test_validate_noise_level_rejects_filtergraph_payloads(value: str) -> None:
+    with pytest.raises(argparse.ArgumentTypeError):
+        PACING.validate_noise_level(value)
+
+
+def test_pacing_rejects_malicious_silence_noise_before_subprocess(tmp_path: Path) -> None:
+    media = tmp_path / "demo.mp4"
+    media.write_bytes(b"video")
+    args = argparse.Namespace(
+        media=media,
+        plan=None,
+        silence_noise="x[out];nullsink",
+        silence_min_duration=0.45,
+        freeze_noise="-50dB",
+        freeze_min_duration=1.0,
+        max_silence_ratio=0.18,
+        max_silence_segment=1.75,
+        max_low_motion_ratio=0.40,
+        max_low_motion_segment=4.0,
+        json_out=None,
+    )
+    run_mock = mock.Mock()
+    stderr = io.StringIO()
+    with (
+        mock.patch.object(PACING, "parse_args", return_value=args),
+        mock.patch.object(PACING.shutil, "which", return_value="/usr/bin/tool"),
+        mock.patch.object(PACING, "run", run_mock),
+        mock.patch.object(sys, "stderr", stderr),
+    ):
+        result = PACING.main()
+
+    assert result == 2
+    assert run_mock.call_count == 0
+    assert "invalid noise level" in stderr.getvalue()
+
+
+def test_pacing_rejects_malicious_freeze_noise_before_subprocess(tmp_path: Path) -> None:
+    media = tmp_path / "demo.mp4"
+    media.write_bytes(b"video")
+    args = argparse.Namespace(
+        media=media,
+        plan=None,
+        silence_noise="-35dB",
+        silence_min_duration=0.45,
+        freeze_noise="-50dB;nullsink",
+        freeze_min_duration=1.0,
+        max_silence_ratio=0.18,
+        max_silence_segment=1.75,
+        max_low_motion_ratio=0.40,
+        max_low_motion_segment=4.0,
+        json_out=None,
+    )
+    run_mock = mock.Mock()
+    stderr = io.StringIO()
+    with (
+        mock.patch.object(PACING, "parse_args", return_value=args),
+        mock.patch.object(PACING.shutil, "which", return_value="/usr/bin/tool"),
+        mock.patch.object(PACING, "run", run_mock),
+        mock.patch.object(sys, "stderr", stderr),
+    ):
+        result = PACING.main()
+
+    assert result == 2
+    assert run_mock.call_count == 0
+    assert "invalid noise level" in stderr.getvalue()
+
+
+def test_pacing_cli_rejects_malicious_noise_flags(tmp_path: Path) -> None:
+    media = tmp_path / "demo.mp4"
+    media.write_bytes(b"video")
+    with mock.patch.object(
+        sys,
+        "argv",
+        [
+            "analyze_demo_pacing.py",
+            str(media),
+            "--silence-noise",
+            "x[out];nullsink",
+        ],
+    ):
+        with pytest.raises(SystemExit) as exc_info:
+            PACING.parse_args()
+    assert exc_info.value.code == 2


### PR DESCRIPTION
## Summary
- Add a strict `^-?[0-9]+(\.[0-9]+)?dB$` allowlist for `--silence-noise` / `--freeze-noise` so filtergraph metacharacters cannot be interpolated into ffmpeg `-af`/`-vf`.
- Validate at argparse `type=` and again in `main()` before filter construction so Namespace/test paths cannot bypass CLI typing.
- Add regression tests that reject payloads such as `x[out];nullsink` before `subprocess.run`.

Closes #198

## Test plan
- [x] `python3 -m py_compile skills/build-product-demo/scripts/analyze_demo_pacing.py`
- [x] `pytest tests/test_build_product_demo.py -q -k 'noise or pacing'` (28 passed)
- [ ] Confirm defaults `-35dB` / `-50dB` still accepted via CLI
- [ ] Confirm malicious `--silence-noise 'x[out];nullsink'` exits before ffmpeg


Made with [Cursor](https://cursor.com)